### PR TITLE
Add doc string to tripping

### DIFF
--- a/disorder-core/src/Disorder/Core/Tripping.hs
+++ b/disorder-core/src/Disorder/Core/Tripping.hs
@@ -4,7 +4,7 @@ import           Control.Applicative
 
 import           Test.QuickCheck
 
-
+-- | Generalized round-trip property function
 tripping :: (Applicative f, Show (f a), Eq (f a)) => (a -> b) -> (b -> f a) -> a -> Property
 tripping to fro a =
   (fro . to) a === pure a


### PR DESCRIPTION
Makes is slightly clearer what `tripping` is for when it turns up in hoogle.