### PR TITLE
Combinators for riding EitherT all the way to the top of property tests

### DIFF
--- a/disorder-core/disorder-core.cabal
+++ b/disorder-core/disorder-core.cabal
@@ -17,7 +17,7 @@ library
                      , text                            >= 1.1        && < 1.3
                      , process                         == 1.2.*
                      , QuickCheck                      == 2.7.*
-                     , either                          >= 4.4
+                     , either                          >= 4.3        && < 4.5
 
   ghc-options:
                        -Wall

--- a/disorder-core/disorder-core.cabal
+++ b/disorder-core/disorder-core.cabal
@@ -17,6 +17,7 @@ library
                      , text                            >= 1.1        && < 1.3
                      , process                         == 1.2.*
                      , QuickCheck                      == 2.7.*
+                     , either                          >= 4.4
 
   ghc-options:
                        -Wall


### PR DESCRIPTION
Just opening this for discussion

EitherT is great - can be fiddly in tests, I found these helpful. 

![](http://cdn.meme.am/instances2/500x/558853.jpg)


Downside is this adds an either dep to disorder-core, so not sure if good idea. 
These could go in IO but they are not necessarily specific to IO monad
