### PR TITLE
removing the evil dropbear from quickcheck

### DIFF
--- a/disorder-core/disorder-core.cabal
+++ b/disorder-core/disorder-core.cabal
@@ -37,6 +37,7 @@ library
                        Disorder.Core.Property
                        Disorder.Core.Tripping
                        Disorder.Core.UniquePair
+                       Disorder.Core.QuickCheck
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/disorder-core/src/Disorder/Core/QuickCheck.hs
+++ b/disorder-core/src/Disorder/Core/QuickCheck.hs
@@ -1,0 +1,6 @@
+module Disorder.Core.QuickCheck (
+    module X
+  ) where
+
+-- the "dropbear" .&. is bad, and you should feel bad
+import           Test.QuickCheck as X hiding ((.&.))


### PR DESCRIPTION
Seen the evil dropbear .&. one too many times. 

using Disorder.QuickCheck (instead of Test.QuickCheck) could prevent bloodloss. 

(was @domdere's idea, honest).