### PR TITLE
Simple FSM testing for QuickCheck

### DIFF
--- a/disorder-fsm/.ghci
+++ b/disorder-fsm/.ghci
@@ -1,0 +1,4 @@
+:set prompt "λ> "
+:set -Wall
+:set -XOverloadedStrings
+:set -XScopedTypeVariables

--- a/disorder-fsm/cabal
+++ b/disorder-fsm/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/disorder-fsm/disorder-fsm.cabal
+++ b/disorder-fsm/disorder-fsm.cabal
@@ -1,0 +1,45 @@
+name:                  disorder-fsm
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              Final state machine testing
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           Final state machine testing.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , transformers                    >= 0.3        && < 0.5
+                     , exceptions                      == 0.8.*
+                     , QuickCheck                      == 2.7.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       Paths_disorder_fsm
+                       Disorder.FSM
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base
+                     , transformers
+                     , QuickCheck
+                     , disorder-fsm

--- a/disorder-fsm/src/Disorder/FSM.hs
+++ b/disorder-fsm/src/Disorder/FSM.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LambdaCase #-}
+module Disorder.FSM (
+  -- * Transition type and constructor
+    Transition
+  , mkTransition
+  -- * Combinators to make 'Transition' less trivial
+  , goif
+  , goto
+  -- * Stubs for combinators arguments
+  , always
+  , sameState
+  -- * Transition evaluation
+  , runFSM
+  ) where
+
+import           Prelude (Show(..))
+import           Data.Bool
+import           Data.String
+import           Data.Maybe
+import           Data.Function
+import           Data.Monoid
+import           Control.Monad
+import           Control.Monad.Catch
+
+import           Test.QuickCheck.Gen
+import           Test.QuickCheck.Monadic
+import           Test.QuickCheck.Property
+
+
+-- | Defines a transition from state to state
+data Transition e s m = MkTransition {
+    -- | Display name (used in case of failure)
+    name :: String
+    -- | Predicate which determines of this transition is applicable for a given state 's'
+  , preCond :: s -> Bool
+    -- | Transition from state 's' given environment 'e'
+    --   Assertion logic can be placed in 'PropertyM m s'
+  , transition :: e -> s -> PropertyM m s
+  }
+
+instance Show (Transition e s m) where
+  show = name
+
+-- | Constructor for 'Transition'
+--   Create unconditional 'Transition' which does nothing
+mkTransition :: Monad m => String -> Transition e s m
+mkTransition name' = MkTransition name' always sameState
+
+-- | Define condition to 'Transition'
+goif :: Transition e s m -> (s -> Bool) -> Transition e s m
+goif t preCond' = t { preCond = preCond' }
+
+-- | Define transition logic
+goto :: Transition e s m -> (e -> s -> PropertyM m s) -> Transition e s m
+goto t transition' = t { transition = transition' }
+
+-- | Do not change the state or eval any monadic actions
+sameState :: Monad m => e -> s -> PropertyM m s
+sameState _ s = return s
+
+-- | Make 'Transition' unconditional
+always :: s -> Bool
+always = const True
+
+
+-- | Generate and execute a list of 'Transition's
+--   given environment 'env' and initial state 'state'
+--   For longer running 'Transition's limit the list produced by 'g'
+runFSM :: (Show s, Monad m, MonadCatch m) => e -> s -> Gen [Transition e s m] -> PropertyM m s
+runFSM env state g = forAllM g $ foldM runTransition state
+  where
+    runTransition s t = do
+      pre (preCond t s) -- discard the transition if preCond t s == False
+      handleError t s -- add transition chain to QuickCheck error in case of failure
+      transition t env s `catchProp` handleException -- catch all exceptions converting them into failure
+
+    handleError t s = monitor (mapTotalResult (addFailureReason t s))
+
+    handleException :: Monad m => SomeException -> PropertyM m s
+    handleException e = fail $ "Exception thrown: " <> show e
+
+    addFailureReason t s = \case
+      r@MkResult{ ok = Just False } -> r { reason = formatState t s <> reason r}
+      r -> r
+
+    formatState t s = "\n(" <> show s <> ") -> " <> name t <> " -> "
+
+
+-- | There is no MonadCatch instance for PropertyM so here is how it could be implemented
+catchProp :: (Exception e, MonadCatch m) => PropertyM m a -> (e -> PropertyM m a) -> PropertyM m a
+catchProp (MkPropertyM f) g = MkPropertyM $ \h -> f h `catchGen` \e -> unPropertyM (g e) h
+
+catchGen :: (Exception e, MonadCatch m) => Gen (m a) -> (e -> Gen (m a)) -> Gen (m a)
+catchGen (MkGen f) g = MkGen $ \q i -> f q i `catch` \e -> unGen (g e) q i

--- a/disorder-fsm/test/Test/Disorder/FSM.hs
+++ b/disorder-fsm/test/Test/Disorder/FSM.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Test.Disorder.FSM where
+
+import           Data.IORef
+import           Data.Monoid
+import           Control.Applicative hiding (empty)
+import           Control.Monad
+import           Control.Monad.IO.Class
+
+import           Disorder.FSM
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+
+
+newtype Stack a = Stack {
+    _toRef :: IORef [a]
+  }
+
+empty :: IO (Stack a)
+empty = Stack <$> newIORef []
+
+push :: Stack a -> a -> IO ()
+push (Stack r) a = modifyIORef r (a:)
+
+pop :: Stack a -> IO a
+pop (Stack r) = readIORef r >>= \case
+  [] -> fail "Empty stack"
+  (a:ls) -> do
+    writeIORef r ls
+    return a
+
+top :: Stack a -> IO (Maybe a)
+top (Stack r) = readIORef r >>= \case
+  [] -> return Nothing
+  ls -> return $ Just (head ls)
+
+size :: Stack a -> IO Int
+size (Stack r) = readIORef r >>= return . length
+
+
+type StackTransition a = Transition (Stack a) [a] IO
+
+genPush :: Gen (StackTransition Int)
+genPush = do
+  a <- arbitrary
+  return $ mkTransition ("push " ++ show a) `goto` \s l -> do
+    liftIO $ push s a
+    return (a:l)
+
+-- | Broken 'push' which doesn't actually push negative elements
+genInvalidPush :: Gen (StackTransition Int)
+genInvalidPush = do
+  a <- arbitrary
+  return $ mkTransition ("invalid_push " ++ show a) `goto` \s l -> do
+    unless (a < 0) $ liftIO $ push s a
+    return (a:l)
+
+
+genPop :: Gen (StackTransition Int)
+genPop =
+  return $ mkTransition "pop" `goif` (not . null) `goto` \s l -> do
+    a <- liftIO $ pop s
+    assert (a == head l)
+    return $ tail l
+
+-- | Does not specify preCondition so the assertion can fail
+genInvalidPop :: Gen (StackTransition Int)
+genInvalidPop =
+  return $ mkTransition "invalid_pop" `goto` \s l -> do
+    assert (not . null $ l)
+    a <- liftIO $ pop s
+    assert (a == head l)
+    return $ tail l
+
+-- | Does not specify preCondition so it will throw exception
+genPopException :: Gen (StackTransition Int)
+genPopException =
+  return $ mkTransition "invalid_pop" `goto` \s l -> do
+    a <- liftIO $ pop s
+    assert (a == head l)
+    return $ tail l
+
+genTop :: Gen (StackTransition Int)
+genTop =
+  return $ mkTransition "top" `goto` \s l -> do
+    ma <- liftIO $ top s
+    case (ma, l) of
+      (Just a, (x:_)) -> assert $ a == x
+      (Nothing, _) -> assert $ l == []
+      inv -> fail $ "invalid state: " <> show inv
+    return l
+
+genSize :: Gen (StackTransition Int)
+genSize =
+  return $ mkTransition "size" `goto` \s l -> do
+    ss <- liftIO $ size s
+    _ <- stop $ ss === length l
+    return l
+
+
+prop_success :: Property
+prop_success = monadicIO $ do
+  s <- liftIO empty
+  runFSM s [] (listOf $ oneof [genPush, genPop, genTop, genSize])
+
+prop_pop_assert_error :: Property
+prop_pop_assert_error = expectFailure . monadicIO $ do
+  s <- liftIO empty
+  runFSM s [] . listOf . oneof $ [genPush, genInvalidPop, genTop, genSize]
+
+prop_push_assert_error :: Property
+prop_push_assert_error = expectFailure . monadicIO $ do
+  s <- liftIO empty
+  runFSM s [] . listOf . oneof $ [genInvalidPush, genPush, genPop, genTop, genSize]
+
+
+-- | Produces "invalid" transition less frequently
+--   thus generating longer transition list
+prop_assert_error_longer_chain :: Property
+prop_assert_error_longer_chain = expectFailure . monadicIO $ do
+  s <- liftIO empty
+  runFSM s [] . vectorOf 100 . frequency $ [
+      (10, genPush)
+    , (1, genInvalidPush)
+    , (10, genTop)
+    , (10, genPop)
+    , (1, genInvalidPop)
+    , (10, genSize)
+    ]
+
+prop_state_exception :: Property
+prop_state_exception = expectFailure . monadicIO $ do
+  s <- liftIO empty
+  runFSM s [] . listOf . oneof $ [genPush, genPopException, genTop, genSize]
+
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/disorder-fsm/test/test.hs
+++ b/disorder-fsm/test/test.hs
@@ -1,0 +1,13 @@
+import           Control.Monad
+
+import qualified Test.Disorder.FSM
+
+import           System.Exit
+import           System.IO
+
+
+main :: IO ()
+main =
+  hSetBuffering stdout LineBuffering >> sequence [
+      Test.Disorder.FSM.tests
+    ] >>= \rs -> unless (and rs) exitFailure


### PR DESCRIPTION
Useful for IO actions testing for stateful systems: given a set of transition definitions between states generates a set of transitions and runs them with QuickCheck.

Current limitations: does not print the chain of transitions if case exception occurs.