### PR TITLE
Re-export UTF8 generators from quickcheck-text

### DIFF
--- a/disorder-core/disorder-core.cabal
+++ b/disorder-core/disorder-core.cabal
@@ -13,11 +13,12 @@ description:           disorder-core.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , directory                       == 1.2.*
-                     , text                            >= 1.1        && < 1.3
-                     , process                         == 1.2.*
                      , QuickCheck                      == 2.7.*
+                     , directory                       == 1.2.*
                      , ieee754                         == 0.7.*
+                     , quickcheck-text                 == 0.1.*
+                     , process                         == 1.2.*
+                     , text                            >= 1.1        && < 1.3
 
   ghc-options:
                        -Wall

--- a/disorder-core/src/Disorder/Core/Gen.hs
+++ b/disorder-core/src/Disorder/Core/Gen.hs
@@ -2,10 +2,17 @@ module Disorder.Core.Gen (
     vectorOfSize
   , chooseSize
   , maybeGen
+  -- * re-exports from quickcheck-text
+  , genValidUtf8
+  , genValidUtf81
+  , utf8BS
+  , utf8BS1
   ) where
 
-import           Test.QuickCheck.Gen
 import           Control.Applicative
+
+import           Test.QuickCheck.Gen
+import           Test.QuickCheck.Utf8
 
 -- | Return a vector whose size is within the provided bounds
 vectorOfSize :: Int -> Int -> Gen a -> Gen [a]


### PR DESCRIPTION
Just to make it less effort to test with non-ASCII character sets when appropriate rather than always using the ASCII-only corpus, which I think is something we want to encourage.

/cc @charleso 