### PR TITLE
Add rudimentary utilities for Haskell-style CLI tests

### DIFF
--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -1,0 +1,31 @@
+name:                  ambiata-disorder-cli
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              disorder-cli
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           disorder-cli.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , directory                       == 1.2.*
+                     , ieee754                         == 0.7.*
+                     , process                         == 1.2.*
+                     , text                            >= 1.1        && < 1.3
+                     , turtle                          == 1.2.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       Paths_ambiata_disorder_cli
+                       Disorder.Cli.Shell

--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -29,3 +29,18 @@ library
   exposed-modules:
                        Paths_ambiata_disorder_cli
                        Disorder.Cli.Shell
+
+test-suite test-io
+  type:                exitcode-stdio-1.0
+  main-is:             test-io.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base                            >= 3           && < 5
+                     , QuickCheck                      == 2.7.*
+                     , ambiata-disorder-cli
+                     , directory                       == 1.2.*
+                     , ieee754                         == 0.7.*
+                     , process                         == 1.2.*
+                     , text                            >= 1.1        && < 1.3
+                     , turtle                          == 1.2.*
+

--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -13,6 +13,7 @@ description:           disorder-cli.
 library
   build-depends:
                        base                            >= 3          && < 5
+                     , clock                           == 0.5.*
                      , directory                       == 1.2.*
                      , ieee754                         == 0.7.*
                      , process                         == 1.2.*

--- a/disorder-cli/mafia
+++ b/disorder-cli/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/disorder-cli/src/Disorder/Cli/Shell.hs
+++ b/disorder-cli/src/Disorder/Cli/Shell.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Disorder.Cli.Shell (
+    testShell
+  , testShell'
+  , cliOutput
+  ) where
+
+import qualified Data.Text           as T
+
+import           Turtle
+
+-- | We could just use execve rather than building a string to pass to a
+-- shell, but we want to simulate an interactive shell/shell script as
+-- as closely as possible.
+--
+-- Of course, as this function directly passes its input to a shell, it should
+-- never be used for anything except a test with no uncontrolled input.
+testShell :: [Text] -> Shell Text -> IO (ExitCode, Text)
+testShell args = shellStrict args'
+  where
+    args' = T.intercalate " " args
+
+testShell' :: [Text] -> IO (ExitCode, Text)
+testShell' = flip testShell empty
+
+-- | Render the 'Text' value expected from a line of output.
+cliOutput :: (Show a) => a -> Text
+cliOutput = flip T.snoc '\n' . T.pack . show

--- a/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
+++ b/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
@@ -17,6 +17,8 @@ import           Test.QuickCheck.Monadic
 
 import           Turtle
 
+import           Prelude
+
 boring :: Gen Text
 boring = fmap T.pack . listOf1 $ elements (['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'])
 

--- a/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
+++ b/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.IO.Disorder.Cli.Shell where
+
+import           Control.Applicative
+
+import           Data.Monoid
+import qualified Data.Text               as T
+
+import           Disorder.Cli.Shell
+
+import           System.Exit
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+
+import           Turtle
+
+boring :: Gen Text
+boring = fmap T.pack . listOf1 $ elements (['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'])
+
+prop_testShell :: Property
+prop_testShell = forAll (listOf1 boring) $ \ms -> (monadicIO . (=<<) stop . run) $ do
+  (st, out) <- testShell ["tac"] $ select ms
+  pure $ (st, out) === (ExitSuccess, flip T.snoc '\n' $ T.intercalate "\n" (reverse ms))
+
+prop_testShell_succ :: Property
+prop_testShell_succ = forAll boring $ \m -> (monadicIO . (=<<) stop . run) $ do
+  (st, out) <- testShell' ["echo", "-n", m]
+  pure $ (st, out) === (ExitSuccess, m)
+
+prop_testShell_fail :: Property
+prop_testShell_fail = forAll boring $ \m -> (monadicIO . (=<<) stop . run) $ do
+  (st, out) <- testShell' ["echo", "-n", m, "&&", "false"]
+  pure $ (st == ExitSuccess, out) === (False, m)
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/disorder-cli/test/test-io.hs
+++ b/disorder-cli/test/test-io.hs
@@ -1,0 +1,13 @@
+import           Control.Monad
+
+import qualified Test.IO.Disorder.Cli.Shell
+
+import           System.Exit
+import           System.IO
+
+main :: IO ()
+main = hSetBuffering stdout LineBuffering >>
+  sequence [
+      Test.IO.Disorder.Cli.Shell.tests
+  ] >>= \rs -> unless (and rs) exitFailure
+


### PR DESCRIPTION
The less shellscript I write, the fewer bugs I find in my code (how odd!) - so I've been writing my CLI tests in Haskell (see e.g., histrionic). What's here now is very rudimetary, so this is more of an RFC on the whole CLI-tests-in-Haskell thing in general.