### PR TITLE
Add areEquivalent property test

### DIFF
--- a/disorder-core/src/Disorder/Core/Property.hs
+++ b/disorder-core/src/Disorder/Core/Property.hs
@@ -3,9 +3,9 @@ module Disorder.Core.Property (
   , (~~~)
   , (.^.)
   , (<=>)
+  , (=\\=)
   , failWith
   , neg
-  , areEquivalent
   ) where
 
 import           Data.AEq                 (AEq)
@@ -75,8 +75,15 @@ infixr 1 <=>
 (<=>) :: (Testable p1, Testable p2) => p1 -> p2 -> Property
 a <=> b = (a .&&. b) .||. (neg a .&&. neg b)
 
-areEquivalent :: (Eq a, Show a) => [a] -> [a] -> Property
-areEquivalent ls rs =
+infix 4 =\\=
+-- |
+-- Test equivalence of the lists
+-- i.e. if 'ls' and 'rs' contain the same elements, possible in a different order
+(=\\=) :: (Eq a, Show a) => [a] -> [a] -> Property
+ls =\\= rs =
   let els = ls \\ rs
       ers = rs \\ ls
-  in counterexample ("Lists are not equivalent; extra elements: " ++ show (els,ers)) $ els ++ ers == []
+  in flip counterexample (els ++ ers == []) $
+    "Lists are not equivalent: " ++
+    "(ls \\\\ rs) == " ++ show els ++ " && " ++
+    "(rs \\\\ ls) == " ++ show ers

--- a/disorder-core/src/Disorder/Core/Property.hs
+++ b/disorder-core/src/Disorder/Core/Property.hs
@@ -1,7 +1,16 @@
-module Disorder.Core.Property where
+module Disorder.Core.Property (
+    (=/=)
+  , (~~~)
+  , (.^.)
+  , (<=>)
+  , failWith
+  , neg
+  , areEquivalent
+  ) where
 
 import           Data.AEq                 (AEq)
 import qualified Data.AEq                 as AEQ
+import           Data.List                ((\\))
 import           Data.Text                (Text, unpack)
 
 import           Test.QuickCheck.Gen
@@ -65,3 +74,9 @@ p1 .^. p2 = (p1 .||. p2) .&&. neg (p1 .&&. p2)
 infixr 1 <=>
 (<=>) :: (Testable p1, Testable p2) => p1 -> p2 -> Property
 a <=> b = (a .&&. b) .||. (neg a .&&. neg b)
+
+areEquivalent :: (Eq a, Show a) => [a] -> [a] -> Property
+areEquivalent ls rs =
+  let els = ls \\ rs
+      ers = rs \\ ls
+  in counterexample ("Lists are not equivalent; extra elements: " ++ show (els,ers)) $ els ++ ers == []

--- a/disorder-core/test/Test/Disorder/Core/Property.hs
+++ b/disorder-core/test/Test/Disorder/Core/Property.hs
@@ -53,7 +53,8 @@ prop_negXor x y =
 
 prop_areEquivalent :: (Eq a, Show a) => [a] -> Property
 prop_areEquivalent ls =
-  forAll (shuffle ls) $ areEquivalent ls
+  forAll (shuffle ls) $ \rs ->
+    ls =\\= rs
   where
     shuffle [] = return []
     shuffle xs = do
@@ -63,7 +64,7 @@ prop_areEquivalent ls =
 prop_areNotEquivalent :: (Eq a, Show a) => [a] -> [a] -> Property
 prop_areNotEquivalent ls rs =
  not (all (`elem`ls) rs && all (`elem`rs) ls) ==>
-   expectFailure $ areEquivalent ls rs
+   expectFailure $ ls =\\= rs
 
 
 return []

--- a/disorder-core/test/Test/Disorder/Core/Property.hs
+++ b/disorder-core/test/Test/Disorder/Core/Property.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Disorder.Core.Property where
 
+import           Control.Applicative       ((<$>))
 import           Data.AEq                  (AEq)
 import qualified Data.AEq                  as AEQ
+import           Data.List                 (delete)
 import           Data.Text                 (Text)
 
 import           Disorder.Core
@@ -48,6 +50,21 @@ prop_negEquals x y =
 prop_negXor :: (Arbitrary a, Show a, Eq a) => a -> a -> Property
 prop_negXor x y =
   (x === y) .^. neg (x === y)
+
+prop_areEquivalent :: (Eq a, Show a) => [a] -> Property
+prop_areEquivalent ls =
+  forAll (shuffle ls) $ areEquivalent ls
+  where
+    shuffle [] = return []
+    shuffle xs = do
+      x <- elements xs
+      (x:) <$> shuffle (delete x xs)
+
+prop_areNotEquivalent :: (Eq a, Show a) => [a] -> [a] -> Property
+prop_areNotEquivalent ls rs =
+ not (all (`elem`ls) rs && all (`elem`rs) ls) ==>
+   expectFailure $ areEquivalent ls rs
+
 
 return []
 tests :: IO Bool

--- a/framework/mafia
+++ b/framework/mafia
@@ -28,7 +28,7 @@ run_upgrade () {
 exec_mafia () {
   MAFIA_VERSION=$(awk '/^# Version: / { print $3; exit 0; }' $0)
 
-  if [ "x$MAFIA_VERSION" == "x" ]; then
+  if [ "x$MAFIA_VERSION" = "x" ]; then
     # If we can't find the mafia version, then we need to upgrade the script.
     run_upgrade
   else
@@ -57,7 +57,7 @@ exec_mafia () {
       mv "${MAFIA_PATH}.tmp" "$MAFIA_PATH"
     }
 
-    exec $MAFIA_PATH $@
+    exec $MAFIA_PATH "$@"
   fi
 }
 
@@ -75,4 +75,4 @@ case "$MODE" in
 upgrade) shift; run_$MODE "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: bf16709a264e388d2ea5e2013be553977ad12ba5
+# Version: 3c266ebb9d3ead73c54af2268e0412f62a50981c


### PR DESCRIPTION
Checks if both lists contain the same elements, possibly in a different order
Does not require `Ord` on element.