### PR TITLE
Introduce disorder-eithert

### DIFF
--- a/disorder-eithert/.ghci
+++ b/disorder-eithert/.ghci
@@ -1,0 +1,4 @@
+:set prompt "λ> "
+:set -Wall
+:set -XOverloadedStrings
+:set -XScopedTypeVariables

--- a/disorder-eithert/disorder-eithert.cabal
+++ b/disorder-eithert/disorder-eithert.cabal
@@ -1,0 +1,29 @@
+name:                  ambiata-disorder-eithert
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              disorder-eithert
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           disorder-eithert.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , QuickCheck                      == 2.7.*
+                     , text                            >= 1.1        && < 1.3
+                     , transformers                    == 0.4.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       Paths_ambiata_disorder_eithert
+                       Disorder.Either

--- a/disorder-eithert/mafia
+++ b/disorder-eithert/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/disorder-eithert/src/Disorder/Either.hs
+++ b/disorder-eithert/src/Disorder/Either.hs
@@ -1,0 +1,19 @@
+module Disorder.Either (
+    testEither
+  , testEitherT
+  ) where
+
+import           Control.Monad.Trans.Except (ExceptT, runExceptT)
+
+import           Data.Text (Text, unpack)
+
+import           Test.QuickCheck.Property
+
+
+testEither :: Testable a => (e -> Text) -> Either e a -> Property
+testEither t =
+  either (flip counterexample False . unpack . t) property 
+
+testEitherT :: (Functor m, Testable a) => (e -> Text) -> ExceptT e m a -> m Property
+testEitherT t =
+  fmap (testEither t) . runExceptT


### PR DESCRIPTION
/cc @markhibberd this what you had in mind?

It might be worth noting `disorder-core` already has a dependency on `transformers`, but it's `>= 3`, and these combinators require `>= 4`.