### PR TITLE
QuickCheck bounds: test libraries (>= 2.7 && < 2.9), test suites (>= 2.8.2 && < 2.9)

### DIFF
--- a/disorder-aeson/ambiata-disorder-aeson.cabal
+++ b/disorder-aeson/ambiata-disorder-aeson.cabal
@@ -15,7 +15,7 @@ library
                        base                            >= 3          && < 5
                      , aeson                           == 0.8.*
                      , ambiata-disorder-core
-                     , QuickCheck                      == 2.8.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , time
 
   ghc-options:
@@ -44,5 +44,5 @@ test-suite test
                        base                            >= 3          && < 5
                      , ambiata-disorder-aeson
                      , aeson
-                     , QuickCheck
+                     , QuickCheck                      >= 2.8.2      && < 2.9
                      , time

--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -37,7 +37,7 @@ test-suite test-io
   ghc-options:         -Wall -threaded -O2
   hs-source-dirs:      test
   build-depends:       base                            >= 3           && < 5
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.8.2       && < 2.9
                      , ambiata-disorder-cli
                      , directory                       == 1.2.*
                      , ieee754                         == 0.7.*

--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -13,7 +13,7 @@ description:           disorder-core.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      == 2.8.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , directory                       == 1.2.*
                      , ieee754                         == 0.7.*
                      , quickcheck-text                 == 0.1.*
@@ -53,7 +53,7 @@ test-suite test
   build-depends:
                        base                            >= 3          && < 5
                      , ambiata-disorder-core
-                     , QuickCheck
+                     , QuickCheck                      >= 2.8.2      && < 2.9
                      , text
                      , quickcheck-instances            == 0.3.*
                      , ieee754                         == 0.7.*

--- a/disorder-corpus/ambiata-disorder-corpus.cabal
+++ b/disorder-corpus/ambiata-disorder-corpus.cabal
@@ -40,5 +40,5 @@ test-suite test
                        base                            >= 3          && < 5
                      , ambiata-disorder-corpus
                      , text
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.8.2      && < 2.9
 

--- a/disorder-eithert/disorder-eithert.cabal
+++ b/disorder-eithert/disorder-eithert.cabal
@@ -13,7 +13,7 @@ description:           disorder-eithert.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      == 2.7.*
+                     , QuickCheck                      >= 2.7        && < 2.9
                      , text                            >= 1.1        && < 1.3
                      , transformers                    == 0.4.*
 

--- a/disorder-fsm/ambiata-disorder-fsm.cabal
+++ b/disorder-fsm/ambiata-disorder-fsm.cabal
@@ -15,7 +15,7 @@ library
                        base                            >= 3          && < 5
                      , transformers                    >= 0.3        && < 0.5
                      , exceptions                      == 0.8.*
-                     , QuickCheck                      == 2.8.*
+                     , QuickCheck                      >= 2.7        && < 2.9
 
   ghc-options:
                        -Wall

--- a/disorder-lens/ambiata-disorder-lens.cabal
+++ b/disorder-lens/ambiata-disorder-lens.cabal
@@ -14,7 +14,7 @@ library
   build-depends:
                        base                            >= 3          && < 5
                      , lens                            >= 4.6        && < 4.10
-                     , QuickCheck                      == 2.8.*
+                     , QuickCheck                      >= 2.7        && < 2.9
 
   ghc-options:
                        -Wall
@@ -41,4 +41,4 @@ test-suite test
                        base                            >= 3          && < 5
                      , ambiata-disorder-lens
                      , lens
-                     , QuickCheck
+                     , QuickCheck                      >= 2.8.2      && < 2.9


### PR DESCRIPTION
Test suites can safely be pinned down to the GHC 7.10/8.0 compatible QuickCheck (>= 2.8.2), but for libraries we want to have wider bounds so that projects downstream are not forced to upgrade.