### PR TITLE
Add testPropertyIO

### DIFF
--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -57,6 +57,7 @@ test-suite test
                      , text
                      , quickcheck-instances            == 0.3.*
                      , ieee754                         == 0.7.*
+                     , transformers                    >= 0.3        && < 1
 
 test-suite test-cli
   type:                exitcode-stdio-1.0

--- a/disorder-core/src/Disorder/Core.hs
+++ b/disorder-core/src/Disorder/Core.hs
@@ -7,4 +7,3 @@ import           Disorder.Core.OrdPair as X
 import           Disorder.Core.Property as X
 import           Disorder.Core.Tripping as X
 import           Disorder.Core.UniquePair as X
-import           Disorder.Core.IO as X

--- a/disorder-core/src/Disorder/Core.hs
+++ b/disorder-core/src/Disorder/Core.hs
@@ -7,3 +7,4 @@ import           Disorder.Core.OrdPair as X
 import           Disorder.Core.Property as X
 import           Disorder.Core.Tripping as X
 import           Disorder.Core.UniquePair as X
+import           Disorder.Core.IO as X

--- a/disorder-core/src/Disorder/Core/IO.hs
+++ b/disorder-core/src/Disorder/Core/IO.hs
@@ -1,5 +1,6 @@
 module Disorder.Core.IO (
     testIO
+  , testPropertyIO
   , withCPUTime
   ) where
 
@@ -12,6 +13,9 @@ import           System.CPUTime (getCPUTime)
 
 testIO :: Testable a => IO a -> Property
 testIO = monadicIO . (=<<) stop . run
+
+testPropertyIO :: Testable a => PropertyM IO a -> Property
+testPropertyIO = monadicIO . (=<<) stop
 
 -- | Perform an action and return the CPU time it takes, in picoseconds
 -- (actual precision varies with implementation).

--- a/disorder-core/src/Disorder/Core/IO.hs
+++ b/disorder-core/src/Disorder/Core/IO.hs
@@ -12,7 +12,7 @@ import           Test.QuickCheck.Monadic
 import           System.CPUTime (getCPUTime)
 
 testIO :: Testable a => IO a -> Property
-testIO = monadicIO . (=<<) stop . run
+testIO = testPropertyIO . run
 
 testPropertyIO :: Testable a => PropertyM IO a -> Property
 testPropertyIO = monadicIO . (=<<) stop

--- a/disorder-core/test/Test/Disorder/Core/IO.hs
+++ b/disorder-core/test/Test/Disorder/Core/IO.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Core.IO where
+
+import           Disorder.Core.IO
+
+import           Control.Monad.IO.Class
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+
+prop_falseFails :: Property
+prop_falseFails
+  = expectFailure $ testPropertyIO $ return False
+
+prop_falseDoesNotFail :: Property
+prop_falseDoesNotFail
+  = monadicIO $ liftIO $ return False
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/disorder-core/test/test.hs
+++ b/disorder-core/test/test.hs
@@ -4,6 +4,7 @@ import qualified Test.Disorder.Core.Property
 import qualified Test.Disorder.Core.Tripping
 import qualified Test.Disorder.Core.UniquePair
 import qualified Test.Disorder.Core.OrdPair
+import qualified Test.Disorder.Core.IO
 
 main :: IO ()
 main = disorderMain [
@@ -12,4 +13,5 @@ main = disorderMain [
   , Test.Disorder.Core.Tripping.tests
   , Test.Disorder.Core.UniquePair.tests
   , Test.Disorder.Core.OrdPair.tests
+  , Test.Disorder.Core.IO.tests
   ]


### PR DESCRIPTION
This is useful when you want to use custom generators:

```
prop_foo
  = testPropertyIO
  $ do x <- pick myCustomGeneratorThatIsNotAnArbitraryInstance
       ...
```

Also eliminates the need to use `monadicIO` because I keep making the mistake of using `monadicIO $ return ...` which makes the test always passes.