### PR TITLE
Add magic newtypes to corpus

### DIFF
--- a/disorder-corpus/ambiata-disorder-corpus.cabal
+++ b/disorder-corpus/ambiata-disorder-corpus.cabal
@@ -13,7 +13,7 @@ description:           disorder-corpus.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , text                            >= 1.1        && < 1.3
+                     , QuickCheck                      >= 2.7        && < 2.9
 
   ghc-options:
                        -Wall

--- a/disorder-corpus/src/Disorder/Corpus.hs
+++ b/disorder-corpus/src/Disorder/Corpus.hs
@@ -1,19 +1,105 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Disorder.Corpus (
-    cooking
+    Cooking(..)
+  , unCooking
+  , cooking
+
+  , Muppet(..)
+  , unMuppet
   , muppets
+
+  , Southpark(..)
+  , unSouthpark
   , southpark
+
+  , Simpson(..)
+  , unSimpson
   , simpsons
+
+  , Virus(..)
+  , unVirus
   , viruses
+
+  , Colour(..)
+  , unColour
   , colours
+
+  , Weather(..)
+  , unWeather
   , weather
+
+  , Water(..)
+  , unWater
   , waters
+
+  , Boat(..)
+  , unBoat
   , boats
   ) where
 
-import           Data.Text
+import           Data.Data (Data)
+import           Data.Eq (Eq)
+import           Data.Functor (fmap)
+import qualified Data.List as List
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord)
+import           Data.String (IsString(..))
+import           Data.Typeable (Typeable)
 
-cooking :: [Text]
+import           GHC.Generics (Generic)
+
+import           Test.QuickCheck (Arbitrary(..), Gen, oneof, elements)
+
+import           Text.Show (Show)
+import           Text.Read (Read)
+
+
+-- | Generate something in the corpus or something completely bonkers.
+genCorpus :: [a] -> (a -> b) -> Gen a -> Gen b
+genCorpus corpus f gen =
+  oneof [
+      fmap f (elements corpus)
+    , fmap f gen
+    ]
+
+-- | Shrinks 'b', preferring to return things from the corpus. If 'b' is
+--   already from the corpus then shrinks to nothing.
+shrinkCorpus :: Eq a => [a] -> (a -> b) -> (b -> a) -> (a -> [a]) -> b -> [b]
+shrinkCorpus corpus f g shrinkA b =
+  let
+    a = g b
+  in
+    if List.elem a corpus then
+      []
+    else
+      -- Items at the start of the shrink list are tried first by QuickCheck,
+      -- so put the corpus items first and hopefully we'll get a nicer
+      -- counterexample.
+      fmap f (corpus <> shrinkA a)
+
+--
+-- The newtypes below have the unXXX function defined separately so that
+-- the derived Show instance produces output which is easier to read.
+--
+
+newtype Cooking a =
+  Cooking a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unCooking :: Cooking a -> a
+unCooking (Cooking x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Cooking a) where
+  arbitrary =
+    genCorpus cooking Cooking arbitrary
+  shrink =
+    shrinkCorpus cooking Cooking unCooking shrink
+
+cooking :: IsString a => [a]
 cooking = [
     "salted"
   , "stewed"
@@ -22,7 +108,22 @@ cooking = [
   , "sauteed"
   ]
 
-muppets :: [Text]
+
+newtype Muppet a =
+  Muppet a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unMuppet :: Muppet a -> a
+unMuppet (Muppet x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Muppet a) where
+  arbitrary =
+    genCorpus muppets Muppet arbitrary
+  shrink =
+    shrinkCorpus muppets Muppet unMuppet shrink
+
+muppets :: IsString a => [a]
 muppets = [
     "kermit"
   , "gonzo"
@@ -34,7 +135,22 @@ muppets = [
   , "animal"
   ]
 
-southpark :: [Text]
+
+newtype Southpark a =
+  Southpark a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSouthpark :: Southpark a -> a
+unSouthpark (Southpark x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Southpark a) where
+  arbitrary =
+    genCorpus southpark Southpark arbitrary
+  shrink =
+    shrinkCorpus southpark Southpark unSouthpark shrink
+
+southpark :: IsString a => [a]
 southpark = [
     "kyle"
   , "stan"
@@ -46,7 +162,21 @@ southpark = [
   ]
 
 
-simpsons :: [Text]
+newtype Simpson a =
+  Simpson a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSimpson :: Simpson a -> a
+unSimpson (Simpson x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Simpson a) where
+  arbitrary =
+    genCorpus simpsons Simpson arbitrary
+  shrink =
+    shrinkCorpus simpsons Simpson unSimpson shrink
+
+simpsons :: IsString a => [a]
 simpsons = [
     "homer"
   , "marge"
@@ -58,7 +188,22 @@ simpsons = [
   , "barney"
   ]
 
-viruses :: [Text]
+
+newtype Virus a =
+  Virus a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unVirus :: Virus a -> a
+unVirus (Virus x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Virus a) where
+  arbitrary =
+    genCorpus viruses Virus arbitrary
+  shrink =
+    shrinkCorpus viruses Virus unVirus shrink
+
+viruses :: IsString a => [a]
 viruses = [
     "rotavirus"
   , "smallpox"
@@ -73,7 +218,22 @@ viruses = [
   , "monkeypox"
   ]
 
-colours :: [Text]
+
+newtype Colour a =
+  Colour a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unColour :: Colour a -> a
+unColour (Colour x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Colour a) where
+  arbitrary =
+    genCorpus colours Colour arbitrary
+  shrink =
+    shrinkCorpus colours Colour unColour shrink
+
+colours :: IsString a => [a]
 colours = [
     "red"
   , "green"
@@ -86,7 +246,22 @@ colours = [
   , "pink"
   ]
 
-weather :: [Text]
+
+newtype Weather a =
+  Weather a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWeather :: Weather a -> a
+unWeather (Weather x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Weather a) where
+  arbitrary =
+    genCorpus weather Weather arbitrary
+  shrink =
+    shrinkCorpus weather Weather unWeather shrink
+
+weather :: IsString a => [a]
 weather = [
     "dry"
   , "raining"
@@ -98,7 +273,22 @@ weather = [
   , "freezing"
   ]
 
-waters :: [Text]
+
+newtype Water a =
+  Water a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWater :: Water a -> a
+unWater (Water x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Water a) where
+  arbitrary =
+    genCorpus waters Water arbitrary
+  shrink =
+    shrinkCorpus waters Water unWater shrink
+
+waters :: IsString a => [a]
 waters = [
     "basin"
   , "bay"
@@ -126,7 +316,22 @@ waters = [
   , "wetland"
   ]
 
-boats :: [Text]
+
+newtype Boat a =
+  Boat a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unBoat :: Boat a -> a
+unBoat (Boat x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Boat a) where
+  arbitrary =
+    genCorpus boats Boat arbitrary
+  shrink =
+    shrinkCorpus boats Boat unBoat shrink
+
+boats :: IsString a => [a]
 boats = [
     "barge"
   , "battleship"


### PR DESCRIPTION
The arbitrary instances for these types generate complete nonsense half of the time, and corpus strings the other half of the time. When shrinking a nonsense input, the corpus is returned. When shrinking something in the corpus, the empty list is returned.

The nice thing about this is that you are testing with all sorts of random data, but 99% of errors will be caught by muppets, so for counterexamples that what we want to see if possible.