### PR TITLE
Export 'genCorpus' and 'shrinkCorpus'

### DIFF
--- a/disorder-corpus/src/Disorder/Corpus.hs
+++ b/disorder-corpus/src/Disorder/Corpus.hs
@@ -3,7 +3,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Disorder.Corpus (
-    Cooking(..)
+    genCorpus
+  , shrinkCorpus
+
+  , Cooking(..)
   , unCooking
   , cooking
 


### PR DESCRIPTION
Forgot to export these on the last PR, they could be useful so might as well