### PR TITLE
Add Unit frequency for non-generator-dependent tests

### DIFF
--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -18,7 +18,7 @@ library
                      , ieee754                         == 0.7.*
                      , process                         == 1.2.*
                      , text                            >= 1.1        && < 1.3
-                     , turtle                          == 1.2.*
+                     , turtle                          == 1.2.5.*
 
   ghc-options:
                        -Wall

--- a/disorder-core/src/Disorder/Core/Run.hs
+++ b/disorder-core/src/Disorder/Core/Run.hs
@@ -25,6 +25,7 @@ data ExpectedTestSpeed
  = TestRunMore
  | TestRunNormal
  | TestRunFewer
+ | TestRunUnit
  deriving (Eq, Ord, Show)
 
 disorderCheckEnv :: Testable prop => ExpectedTestSpeed -> prop -> IO Result
@@ -47,6 +48,7 @@ disorderSpeedEnvArg =
   TestRunMore   -> "DISORDER_RUN_MORE"
   TestRunNormal -> "DISORDER_RUN_NORMAL"
   TestRunFewer  -> "DISORDER_RUN_FEWER"
+  TestRunUnit   -> "DISORDER_RUN_UNIT"
 
 disorderSpeedDefaultRuns :: ExpectedTestSpeed -> Int
 disorderSpeedDefaultRuns =
@@ -54,6 +56,7 @@ disorderSpeedDefaultRuns =
   TestRunMore   -> 1000
   TestRunNormal -> 100
   TestRunFewer  -> 10
+  TestRunUnit   -> 1
 
 
 readEnv :: String -> IO (Maybe Int)


### PR DESCRIPTION
For tests that it only makes sense to run once, e.g., serialization compatibility tests on static files.