### PR TITLE
Require transformers 0.4 or greater for managed

### DIFF
--- a/disorder-cli/disorder-cli.cabal
+++ b/disorder-cli/disorder-cli.cabal
@@ -18,6 +18,9 @@ library
                      , ieee754                         == 0.7.*
                      , process                         == 1.2.*
                      , text                            >= 1.1        && < 1.3
+                     -- Minimum requirement for managed 1.0.3 due to 'Control.Monad.Trans.Except'
+                     -- https://github.com/Gabriel439/Haskell-Managed-Library/issues/6
+                     , transformers                    >= 0.4        && < 0.6
                      , turtle                          == 1.2.*
 
   ghc-options:


### PR DESCRIPTION
/cc @jystic 

```
Preprocessing library managed-1.0.3...

src/Control/Monad/Managed.hs:115:18:
    Could not find module ‘Control.Monad.Trans.Except’
    Perhaps you meant
      Control.Monad.Trans.Cont (from transformers-0.3.0.0)
      Control.Monad.Trans.Error (from transformers-0.3.0.0)
      Control.Monad.Trans.List (from transformers-0.3.0.0)
    Use -v to see a list of the files searched for.
turtle-1.2.6
 └─╼ managed-1.0.3
```