### PR TITLE
Add real-number comparison property

### DIFF
--- a/disorder-core/src/Disorder/Core/Property.hs
+++ b/disorder-core/src/Disorder/Core/Property.hs
@@ -1,6 +1,7 @@
 module Disorder.Core.Property (
     (=/=)
   , (~~~)
+  , (###)
   , (.^.)
   , (<=>)
   , (=\\=)
@@ -30,6 +31,19 @@ x ~~~ y = counterexample cex prop
   where
     cex  = concat ["|", show x, " - ", show y, "| > ɛ"]
     prop = x AEQ.~== y
+
+infix 4 ###
+
+-- | Approximately-equal property for floats, which also verifies that
+-- both arguments are real numbers (i.e., not NaN or infinity).
+(###) :: (AEq a, Show a, RealFloat a) => a -> a -> Property
+x ### y = conjoin [counterexample unreal realProp, x ~~~ y]
+  where
+    unreal = unwords ["Argument is not a real number:", show x, show y]
+
+    realProp = all real [x, y]
+
+    real z = (not $ isNaN z) && (not $ isInfinite z)
 
 failWith :: Text -> Property
 failWith =

--- a/disorder-core/test/Test/Disorder/Core/Property.hs
+++ b/disorder-core/test/Test/Disorder/Core/Property.hs
@@ -68,6 +68,26 @@ prop_areNotEquivalent ls rs =
  not (all (`elem`ls) rs && all (`elem`rs) ls) ==>
    expectFailure $ ls =\\= rs
 
+prop_realEq_pos :: Int -> Property
+prop_realEq_pos x =
+  x' ### x'
+  where
+    x' :: Double
+    x' = fromIntegral x
+
+prop_realEq_neg :: Double -> Property
+prop_realEq_neg n = forAll (elements [0 / 0, n / 0] :: Gen Double) $ \bad ->
+  expectFailure $ bad ### bad
+
+prop_realEq_neq :: UniquePair Int -> Property
+prop_realEq_neq (UniquePair n m) =
+  expectFailure $ n' ### m'
+  where
+    n' :: Double
+    n' = fromIntegral n
+
+    m' :: Double
+    m' = fromIntegral m
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
This fails if either argument is infinite or `NaN` and otherwise acts as `~~~`. So we catch overflow/nonsensical results in floating-point computations.

Fixes #75.

@charleso @nhibberd 