### PR TITLE
Bump quickcheck-text

### DIFF
--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -16,7 +16,7 @@ library
                      , QuickCheck                      >= 2.7        && < 2.9
                      , directory                       == 1.2.*
                      , ieee754                         == 0.7.*
-                     , quickcheck-text                 == 0.1.*
+                     , quickcheck-text                 >= 0.1.1      && < 0.2
                      , process                         >= 1.2        && < 1.5
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.3        && < 1

--- a/disorder-core/src/Disorder/Core/Gen.hs
+++ b/disorder-core/src/Disorder/Core/Gen.hs
@@ -5,23 +5,23 @@ module Disorder.Core.Gen (
   , genDeterministic'
   , genEnum
   , genFromMaybe
-
-  -- * re-exports from quickcheck-text
-  , genValidUtf8
-  , genValidUtf81
-
   , listOfSized
   , listOfSizedWithIndex
   , listWithIndex
   , maybeGen
   , oneofSized
   , smaller
+  , vectorOfSize
 
   -- * re-exports from quickcheck-text
+  , genValidUtf8
+  , genValidUtf81
+  , shrinkValidUtf8
+  , shrinkValidUtf81
+  , shrinkUtf8BS
+  , shrinkUtf8BS1
   , utf8BS
   , utf8BS1
-
-  , vectorOfSize
   ) where
 
 import           Control.Applicative

--- a/framework/mafia
+++ b/framework/mafia
@@ -118,4 +118,4 @@ case "$MODE" in
 upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: ac295bb549721e1a11f6f6bf867a79643e0f5422
+# Version: 90cf62f24007515d61be573e8b350b1ad4d1608c


### PR DESCRIPTION
For better gens and shrinkage.

https://github.com/olorin/quickcheck-text/pull/4
https://github.com/olorin/quickcheck-text/pull/5

@jystic 

(ci should build this after `cabal update` tomorrow)