### PR TITLE
Jack

### DIFF
--- a/disorder-jack/.ghci
+++ b/disorder-jack/.ghci
@@ -1,0 +1,4 @@
+:set prompt "λ> "
+:set -Wall
+:set -XOverloadedStrings
+:set -XScopedTypeVariables

--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -36,6 +36,11 @@ library
 
   exposed-modules:
                        Disorder.Jack
+                       Disorder.Jack.Combinators
+                       Disorder.Jack.Core
+                       Disorder.Jack.Property
+                       Disorder.Jack.Shrink
+                       Disorder.Jack.Tree
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -1,0 +1,62 @@
+name:                  ambiata-disorder-jack
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              disorder-jack
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           disorder-jack.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , comonad                         >= 4.2        && < 5.1
+                     , containers                      >= 0.4        && < 0.6
+                     , deepseq                         >= 1.2        && < 1.5
+                     , pretty-show                     >= 1.6        && < 1.7
+                     , QuickCheck                      >= 2.7        && < 2.9
+                     , quickcheck-text                 >= 0.1        && < 0.2
+                     , random                          >= 1.1        && < 1.2
+                     , semigroups                      >= 0.16       && < 0.19
+                     , text                            >= 1.1        && < 1.3
+                     , transformers                    >= 0.3        && < 0.6
+
+  ghc-options:         -Wall
+
+  if impl(ghc >= 8.0)
+    ghc-options:       -fno-warn-redundant-constraints
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       Disorder.Jack
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  if impl(ghc >= 8.0)
+    ghc-options:       -fno-warn-redundant-constraints
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , ambiata-disorder-jack
+                     , comonad                         >= 4.2        && < 5.1
+                     , pretty-show                     >= 1.6        && < 1.7
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+                     , text                            >= 1.1        && < 1.3
+                     , transformers                    >= 0.3        && < 0.6

--- a/disorder-jack/mafia
+++ b/disorder-jack/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/disorder-jack/master.toml
+++ b/disorder-jack/master.toml
@@ -1,0 +1,1 @@
+../framework/master.toml

--- a/disorder-jack/src/Disorder/Jack.hs
+++ b/disorder-jack/src/Disorder/Jack.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Disorder.Jack (
+    module X
+  ) where
+
+import           Disorder.Jack.Combinators as X
+import           Disorder.Jack.Core as X
+import           Disorder.Jack.Property as X
+import           Disorder.Jack.Shrink as X
+import           Disorder.Jack.Tree as X

--- a/disorder-jack/src/Disorder/Jack/Combinators.hs
+++ b/disorder-jack/src/Disorder/Jack/Combinators.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LambdaCase #-}
+module Disorder.Jack.Combinators (
+    arbitrary
+
+  , sized
+  , sizedInt
+  , sizedIntegral
+  , sizedNat
+  , sizedNatural
+
+  , chooseChar
+  , chooseInt
+  , chooseIntegral
+
+  , oneof
+  , elements
+  , list
+  , list1
+  , vector
+  ) where
+
+import           Control.Monad (replicateM)
+import           Control.Applicative (Applicative(..))
+
+import           Data.Bool (not)
+import           Data.Char (Char, ord, chr)
+import           Data.Function (($), (.))
+import           Data.Functor (Functor(..))
+import           Data.Int (Int)
+import qualified Data.List as List
+import           Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
+
+import           Disorder.Jack.Core
+import           Disorder.Jack.Shrink
+import           Disorder.Jack.Tree
+
+import           Prelude (Num(..), Integral, min, max)
+import qualified Prelude as Savage
+
+import           System.Random (Random)
+
+import qualified Test.QuickCheck as QC
+
+
+-- | Construct a 'Jack' using a type's QuickCheck 'QC.Arbitrary' instance.
+arbitrary :: QC.Arbitrary a => Jack a
+arbitrary =
+  mkJack QC.shrink QC.arbitrary
+
+-- | Construct a 'Jack' that depends on the size parameter.
+sized :: (Int -> Jack a) -> Jack a
+sized f =
+  Jack $ QC.sized (runJack . f)
+
+-- | Generates an 'Int'. The number can be positive or negative and its maximum
+--   absolute value depends on the size parameter.
+sizedInt :: Jack Int
+sizedInt =
+  sizedIntegral
+
+-- | Generates an integral number. The number can be positive or negative and
+--   its maximum absolute value depends on the size parameter.
+sizedIntegral :: Integral a => Jack a
+sizedIntegral =
+  mkJack QC.shrinkIntegral QC.arbitrarySizedIntegral
+
+-- | Generates a non-negative 'Int'. The number's maximum value depends on the
+--   size parameter.
+sizedNat :: Jack Int
+sizedNat =
+  sizedNatural
+
+-- | Generates a natural number. The number's maximum value depends on
+--   the size parameter.
+sizedNatural :: Integral a => Jack a
+sizedNatural =
+  mkJack QC.shrinkIntegral QC.arbitrarySizedNatural
+
+-- | Generates a 'Char' in the given range.
+chooseChar :: Char -> Char -> Jack Char
+chooseChar b0 b1 =
+  fmap chr $ chooseIntegral (ord b0) (ord b1)
+
+-- | Generates an 'Int' in the given range.
+chooseInt :: Int -> Int -> Jack Int
+chooseInt =
+  chooseIntegral
+
+-- | Generates an integral number in the given range.
+chooseIntegral :: (Random a, Integral a) => a -> a -> Jack a
+chooseIntegral b0 b1 =
+  let
+    b_min =
+      min b0 b1
+
+    b_max =
+      max b0 b1
+  in
+    mkJack (shrinkIntegral b_min) $ QC.choose (b_min, b_max)
+
+-- | Randomly selects one of jacks in the list.
+--   /The input list must be non-empty./
+oneof :: [Jack a] -> Jack a
+oneof = \case
+  [] ->
+    Savage.error "Disorder.Jack.Combinators.oneof: used with empty list"
+  xs -> do
+    n <- chooseInt 0 (List.length xs - 1)
+    xs List.!! n
+
+-- | Randomly selects one of the values in the list.
+--   /The input list must be non-empty./
+elements :: [a] -> Jack a
+elements = \case
+  [] ->
+    Savage.error "Disorder.Jack.Combinators.elements: used with empty list"
+  xs -> do
+    n <- chooseInt 0 (List.length xs - 1)
+    pure $ xs List.!! n
+
+-- | Generates a list of random length. The maximum length depends on the size
+--   parameter.
+list :: Jack a -> Jack [a]
+list jack =
+  sized $ \n -> do
+    Jack $ do
+      k <- QC.choose (0, n)
+      fmap sequenceShrinkList . replicateM k $ runJack jack
+
+-- | Generates a non-empty list of random length. The maximum length depends on
+--   the size parameter.
+list1 :: Jack a -> Jack (NonEmpty a)
+list1 jack =
+  sized $ \n -> do
+    Jack $ do
+      k <- QC.choose (1, max n 1)
+
+      let
+        unpack = \case
+          [] ->
+            Savage.error "Disorder.Jack.Combinators.list1: internal error, generated empty list"
+          xs ->
+            NonEmpty.fromList xs
+
+        go =
+          fmap unpack .
+          filterTree (not . List.null) .
+          sequenceShrinkList
+
+      fmap go . replicateM k $ runJack jack
+
+-- | Generates a list of the given length.
+vector :: Int -> Jack a -> Jack [a]
+vector n =
+  mapGen (fmap sequenceShrinkOne . replicateM n)

--- a/disorder-jack/src/Disorder/Jack/Core.hs
+++ b/disorder-jack/src/Disorder/Jack/Core.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Disorder.Jack.Core (
+    Jack(..)
+  , mkJack
+  , mkJack_
+
+  , mapGen
+  , mapTree
+
+  , reshrink
+  , withShrink
+  ) where
+
+import           Control.Applicative (Applicative(..), liftA2)
+import           Control.Monad (Monad(..), join)
+
+import           Data.Function (($), (.), const, flip, id)
+import           Data.Functor (Functor(..))
+import           Data.Traversable (traverse)
+
+import           Disorder.Jack.Tree
+
+import           Test.QuickCheck (Gen)
+
+
+-- | Jack's love of dice has brought him here, where he has taken on the form
+--   of a Haskell library, in order to help you gamble with your properties.
+--
+newtype Jack a =
+  Jack {
+      runJack :: Gen (Tree a)
+    }
+
+instance Functor Jack where
+  fmap f =
+    Jack . fmap (fmap f) . runJack
+
+instance Applicative Jack where
+  pure =
+    Jack . pure . pure
+
+  (<*>) f x =
+    Jack $
+      liftA2 (<*>) (runJack f) (runJack x)
+
+instance Monad Jack where
+  return =
+    pure
+
+  (>>=) m0 k0 =
+    let
+      go m k =
+        m >>= fmap join . traverse k
+    in
+      Jack $ go (runJack m0) (runJack . k0)
+
+-- | Create a 'Jack' from a shrink function and a 'Gen'.
+mkJack :: (a -> [a]) -> Gen a -> Jack a
+mkJack shr =
+  Jack . fmap (unfoldTree id shr)
+
+-- | Create a non-shrinking 'Jack' from a 'Gen'.
+mkJack_ :: Gen a -> Jack a
+mkJack_ =
+  mkJack $ const []
+
+-- | Map over the 'Gen' inside of 'Jack'.
+mapGen :: (Gen (Tree a) -> Gen (Tree b)) -> Jack a -> Jack b
+mapGen f =
+  Jack . f . runJack
+
+-- | Map over the 'Tree' inside a 'Jack'.
+mapTree :: (Tree a -> Tree b) -> Jack a -> Jack b
+mapTree =
+  mapGen . fmap
+
+-- | Apply an additional shrinker to all generated trees.
+reshrink :: (a -> [a]) -> Jack a -> Jack a
+reshrink =
+  mapTree . expandTree
+
+-- | Flipped version of 'reshrink'.
+withShrink :: Jack a -> (a -> [a]) -> Jack a
+withShrink =
+  flip reshrink

--- a/disorder-jack/src/Disorder/Jack/Property.hs
+++ b/disorder-jack/src/Disorder/Jack/Property.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LambdaCase #-}
+module Disorder.Jack.Property (
+    gamble
+  , gambleRender
+  , gambleDisplay
+
+  , shrinking
+
+  , sample
+  , sampleTree
+  , printSample
+
+  -- * QuickCheck re-exports
+  , Property(..)
+  , Testable(..)
+  ) where
+
+import           Data.Foldable (for_, traverse_)
+import           Data.Function (($), (.))
+import           Data.Functor (Functor(..))
+import qualified Data.List as List
+import           Data.String (String)
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Disorder.Jack.Core
+import           Disorder.Jack.Tree
+
+import           System.IO (IO, putStrLn)
+
+import           Text.Show (Show)
+import           Text.Show.Pretty (ppShow)
+
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck.Gen.Unsafe (promote)
+import           Test.QuickCheck.Property (Testable(..), Property(..), Prop(..), Rose(..))
+import           Test.QuickCheck.Property (joinRose)
+
+
+-- | Ask 'Jack' to generate test cases to exercise the given property.
+gamble :: (Show a, Testable prop) => Jack a -> (a -> prop) -> Property
+gamble jack =
+  gambleDisplay jack ppShow
+
+-- | Ask 'Jack' to generate test cases, but provide a custom render function
+--   for displaying counterexampes.
+gambleRender :: Testable prop => Jack a -> (a -> Text) -> (a -> prop) -> Property
+gambleRender jack render =
+  gambleDisplay jack (T.unpack . render)
+
+-- | Ask 'Jack' to generate test cases, but provide a custom render function
+--   for displaying counterexampes.
+gambleDisplay :: Testable prop => Jack a -> (a -> String) -> (a -> prop) -> Property
+gambleDisplay jack render pf =
+  MkProperty $ do
+    tree <- runJack jack
+    unProperty . shrinking tree $ \x ->
+      QC.counterexample (render x) $
+      pf x
+
+-- | Use an existing 'Tree' to exercise a given property.
+shrinking :: Testable prop => Tree a -> (a -> prop) -> Property
+shrinking tree pf =
+  let
+    props x =
+      MkRose
+        (unProperty . property . pf $ outcome x)
+        (fmap props $ shrinks x)
+  in
+    MkProperty .
+      fmap (MkProp . joinRose . fmap unProp) $
+      promote (props tree)
+
+-- | Generate some example outcomes.
+sample :: Jack a -> IO [a]
+sample =
+  fmap (fmap outcome) . QC.sample' . runJack
+
+-- | Generate some example trees.
+sampleTree :: Jack a -> IO [Tree a]
+sampleTree =
+  QC.sample' . runJack
+
+-- | Generate some example outcomes (and shrinks) and prints them to 'stdout'.
+printSample :: Show a => Jack a -> IO ()
+printSample jack = do
+  forest <- fmap (List.take 5) $ sampleTree jack
+  for_ forest $ \tree -> do
+    putStrLn "=== Outcome ==="
+    putStrLn . ppShow $ outcome tree
+    putStrLn "=== Shrinks ==="
+    traverse_ (putStrLn . ppShow . outcome) $ shrinks tree
+    putStrLn ""

--- a/disorder-jack/src/Disorder/Jack/Shrink.hs
+++ b/disorder-jack/src/Disorder/Jack/Shrink.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Disorder.Jack.Shrink (
+    shrinkIntegral
+
+  , sequenceShrink
+  , sequenceShrinkOne
+  , sequenceShrinkList
+
+  , shrinkOne
+  , shrinkList
+
+  , halves
+  , removes
+  ) where
+
+import           Data.Ord (Ord(..))
+import           Data.Functor (fmap)
+import           Data.Function (($), (.))
+import           Data.Monoid ((<>))
+import qualified Data.List as List
+import           Data.Int (Int)
+
+import           Disorder.Jack.Tree
+
+import           Prelude (Num(..), Integral, div)
+
+import qualified Test.QuickCheck.Arbitrary as QC
+
+
+-- | Shrink an integral, but don't allow it to go below the specified minimum.
+shrinkIntegral :: Integral a => a -> a -> [a]
+shrinkIntegral x_min x =
+  fmap (+ x_min) $ QC.shrinkIntegral (x - x_min)
+
+-- | Turn a list of trees in to a tree of lists, opting to shrink only the
+--   elements of the list (i.e. the size of the list will always be the same).
+--
+sequenceShrinkOne :: [Tree a] -> Tree [a]
+sequenceShrinkOne =
+  sequenceShrink (\xs -> shrinkOne shrinks xs)
+
+-- | Turn a list of trees in to a tree of lists, opting to shrink both the list
+--   itself and the elements in the list during traversal.
+--
+sequenceShrinkList :: [Tree a] -> Tree [a]
+sequenceShrinkList =
+  sequenceShrink (\xs -> shrinkList xs <> shrinkOne shrinks xs)
+
+-- | Turn a list of trees in to a tree of lists, using the supplied function to
+--   merge shrinking options.
+--
+sequenceShrink :: ([Tree a] -> [[Tree a]]) -> [Tree a] -> Tree [a]
+sequenceShrink merge xs =
+  Node
+    (fmap outcome xs)
+    (fmap (sequenceShrink merge) $ merge xs)
+
+-- | Shrink each of the elements in input list using the supplied shrinking
+--   function.
+--
+shrinkOne :: (a -> [a]) -> [a] -> [[a]]
+shrinkOne shr = \case
+  [] ->
+    []
+  x0 : xs0 ->
+    [ x1 : xs0 | x1 <- shr x0 ] <>
+    [ x0 : xs1 | xs1 <- shrinkOne shr xs0 ]
+
+-- | Produce a smaller permutation of the input list.
+--
+shrinkList :: [a] -> [[a]]
+shrinkList xs = do
+ List.concatMap
+   (\k -> removes k xs)
+   (halves $ List.length xs)
+
+-- | Produces a list containing the results of halving a number over and over
+--   again.
+--
+--   > halves 30 == [30,15,7,3,1]
+--   > halves 128 == [128,64,32,16,8,4,2,1]
+--
+halves :: Int -> [Int]
+halves =
+  List.takeWhile (> 0) .
+  List.iterate (`div` 2)
+
+-- | Permutes a list by removing 'k' consecutive elements from it:
+--
+--   > removes 2 [1,2,3,4,5,6] == [[3,4,5,6],[1,2,5,6],[1,2,3,4]]
+--
+removes :: Int -> [a] -> [[a]]
+removes k0 xs0 =
+  let
+    loop k n xs =
+      let
+        hd = List.take k xs
+        tl = List.drop k xs
+      in
+        if k > n then
+          []
+        else if List.null tl then
+          [[]]
+        else
+          tl : fmap (hd <>) (loop k (n - k) tl)
+  in
+    loop k0 (List.length xs0) xs0

--- a/disorder-jack/src/Disorder/Jack/Tree.hs
+++ b/disorder-jack/src/Disorder/Jack/Tree.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Disorder.Jack.Tree (
+    Tree(..)
+  , foldTree
+  , foldForest
+  , unfoldTree
+  , unfoldForest
+  , filterTree
+  , filterForest
+  , expandTree
+  ) where
+
+import           Control.Applicative (Applicative(..))
+import           Control.Comonad (Comonad(..), ComonadApply(..))
+import           Control.DeepSeq (NFData(..))
+import           Control.Monad (Monad(..))
+
+import           Data.Bool (Bool)
+import           Data.Data (Data)
+import           Data.Eq (Eq)
+import           Data.Foldable (Foldable(..))
+import           Data.Function (($), (.), id)
+import           Data.Functor (Functor(..), (<$>))
+import qualified Data.List as List
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord)
+import           Data.Traversable (Traversable(..))
+import           Data.Typeable (Typeable)
+
+import           GHC.Generics (Generic)
+
+import           Prelude (seq)
+
+import           Text.Show (Show)
+
+
+-- | A rose tree which represents a random generated outcome, and all the ways
+--   in which it can be made smaller.
+--
+--   This tree is exactly the same as 'Data.Tree' in every way except that
+--   Applicative '<*>' and Monad '>>=' walk the tree in the reverse order. This
+--   modification is critical for shrinking to reach a minimal counterexample.
+--
+data Tree a =
+  Node {
+    -- | The generated outcome.
+    outcome :: !a
+
+    -- | All the possible shrinks of this outcome. This should be ordered
+    --   smallest to largest as if property still fails with the first shrink in
+    --   the list then we will commit to that path and none of the others will
+    --   be tried (i.e. there is no backtracking).
+  , shrinks :: [Tree a]
+  } deriving (Eq, Ord, Show, Generic, Data, Typeable)
+
+instance Functor Tree where
+  fmap f (Node x xs) =
+    Node (f x) $ fmap (fmap f) xs
+
+instance Applicative Tree where
+  pure x =
+    Node x []
+
+  (<*>) (Node f fs) x@(Node y ys) =
+      Node (f y) $
+      -- Data.Tree would have `fmap (f <$>) ys <> fmap (<*> x) fs`
+        fmap (<*> x) fs <>
+        fmap (f <$>) ys
+
+instance Monad Tree where
+  return =
+    pure
+
+  (>>=) (Node x xs) k =
+    let
+      Node y ys = k x
+    in
+      Node y $
+      -- Data.Tree would have `ys <> fmap (>>= k) xs`
+        fmap (>>= k) xs <> ys
+
+instance Traversable Tree where
+  traverse f (Node x xs) =
+    Node <$> f x <*> traverse (traverse f) xs
+
+instance Foldable Tree where
+  foldMap f (Node x xs) =
+    f x <> foldMap (foldMap f) xs
+
+instance Comonad Tree where
+  extract (Node x _) =
+    x
+
+  duplicate x@(Node _ ys) =
+    Node x (fmap duplicate ys)
+
+instance ComonadApply Tree where
+  (<@>) =
+    (<*>)
+
+  (<@) =
+    (<*)
+
+  (@>) =
+    (*>)
+
+instance NFData a => NFData (Tree a) where
+  rnf (Node x xs) =
+    rnf x `seq` rnf xs
+
+-- | Fold over a 'Tree'.
+foldTree :: (a -> x -> b) -> ([b] -> x) -> Tree a -> b
+foldTree f g (Node x xs) =
+  f x (foldForest f g xs)
+
+-- | Fold over a list of trees.
+foldForest :: (a -> x -> b) -> ([b] -> x) -> [Tree a] -> x
+foldForest f g =
+  g . fmap (foldTree f g)
+
+-- | Build a 'Tree' from an unfolding function and a seed value.
+unfoldTree :: (b -> a) -> (b -> [b]) -> b -> Tree a
+unfoldTree f g x =
+  Node (f x) (unfoldForest f g x)
+
+-- | Build a list of trees from an unfolding function and a seed value.
+unfoldForest :: (b -> a) -> (b -> [b]) -> b -> [Tree a]
+unfoldForest f g =
+  fmap (unfoldTree f g) . g
+
+-- | Apply an additional unfolding function to an existing tree.
+--
+--   The root outcome remains intact, only the shrinks are affected, this
+--   applies recursively, so shrinks can only ever be added using this
+--   function.
+--
+--   If you want to replace the shrinks altogether, try:
+--
+--   > unfoldTree f (outcome oldTree)
+--
+expandTree :: (a -> [a]) -> Tree a -> Tree a
+expandTree f (Node x xs) =
+  --
+  -- Ideally we could put the 'unfoldForest' nodes before the 'fmap expandTree'
+  -- nodes, so that we're culling from the top down and we would be able to
+  -- terminate our search faster, but this prevents minimal shrinking.
+  --
+  -- We'd need some kind of tree transpose to do this properly.
+  --
+  Node x (fmap (expandTree f) xs <> unfoldForest id f x)
+
+-- | Recursively discard any shrinks whose outcome does not pass the predicate.
+--   /Note that the root outcome can never be discarded./
+filterTree :: (a -> Bool) -> Tree a -> Tree a
+filterTree f (Node x xs) =
+  Node x (filterForest f xs)
+
+-- | Recursively discard any trees whose outcome does not pass the predicate.
+filterForest :: (a -> Bool) -> [Tree a] -> [Tree a]
+filterForest f =
+  fmap (filterTree f) . List.filter (f . outcome)

--- a/disorder-jack/test/Test/Disorder/Jack/Shrink.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Shrink.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Shrink where
+
+import           Control.Applicative (Applicative(..), Alternative(..))
+import           Control.Comonad (duplicate)
+import           Control.Monad (Monad(..))
+
+import           Data.Bool (Bool(..), (&&))
+import           Data.Foldable (foldl)
+import           Data.Function (($), (.))
+import           Data.Functor (Functor(..), (<$>))
+import           Data.Int (Int)
+import qualified Data.List as List
+import           Data.Maybe (Maybe(..))
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord(..))
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Disorder.Jack.Combinators
+import           Disorder.Jack.Core
+import           Disorder.Jack.Property
+import           Disorder.Jack.Tree
+
+import           Prelude (Num(..))
+
+import           System.IO (IO)
+
+import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Property as QC
+
+import           Text.Show (Show)
+import           Text.Show.Pretty (ppShow)
+
+
+data Exp =
+    Var !Text
+  | Con !Int
+  | Lam !Text !Exp
+  | App !Exp !Exp
+    deriving (Show)
+
+exp :: Int -> Jack Exp
+exp n =
+  let
+    text =
+      T.pack <$> arbitrary
+
+    exp0 = [
+        Con <$> sizedIntegral
+      , Var <$> text
+      ]
+
+    expN = [
+        Lam <$> text <*> exp (n-1)
+      , App <$> exp (n-1) <*> exp (n-1)
+      ]
+
+    shrink = \case
+      Lam _ x ->
+        [x]
+      App x y ->
+        [x, y]
+      _ ->
+        []
+  in
+    reshrink shrink $
+      oneof (exp0 <> if n > 0 then expN else [])
+
+noAppCon10 :: Exp -> Bool
+noAppCon10 = \case
+  Con _ ->
+    True
+  Var _ ->
+    True
+  Lam _ x ->
+    noAppCon10 x
+  App _ (Con 10) ->
+    False
+  App x1 x2 ->
+    noAppCon10 x1 && noAppCon10 x2
+
+smallestFailure :: (a -> Bool) -> Tree a -> Maybe a
+smallestFailure f (Node x xs) =
+  if f x then
+    Nothing
+  else
+    foldl (<|>) empty (fmap (smallestFailure f) xs) <|> Just x
+
+prop_jack :: Property
+prop_jack =
+  gamble (mapTree duplicate . list $ sized exp) $ \xs ->
+    case smallestFailure (List.all noAppCon10) xs of
+      Nothing ->
+        property QC.succeeded
+      -- The tree must be organised such that smallest fail is found by greedy
+      -- traversal with a predicate.
+      Just [App (Con 0) (Con 10)] ->
+        property QC.succeeded
+      Just x ->
+        QC.counterexample "" .
+        QC.counterexample "Greedy traversal with predicate did not yield the minimal shrink." .
+        QC.counterexample "" .
+        QC.counterexample "=== Minimal ===" .
+        QC.counterexample (ppShow [App (Con 0) (Con 10)]) .
+        QC.counterexample "=== Actual ===" .
+        QC.counterexample (ppShow x) $
+        property QC.failed
+
+return []
+tests :: IO Bool
+tests =
+  $(QC.forAllProperties) . QC.quickCheckWithResult $
+    QC.stdArgs { QC.maxSuccess = 100 }

--- a/disorder-jack/test/Test/Disorder/Jack/Tree.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Tree.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Tree where
+
+import           Control.Applicative (Applicative(..))
+import           Control.Comonad (duplicate)
+import           Control.Monad (Monad(..), ap)
+
+import           Data.Bool (Bool)
+import           Data.Eq (Eq(..))
+import           Data.Functor (Functor(..))
+import           Data.Function (($), (.))
+
+import           Disorder.Jack.Combinators
+import           Disorder.Jack.Core
+import           Disorder.Jack.Property
+import           Disorder.Jack.Tree
+
+import           System.IO (IO)
+
+import qualified Test.QuickCheck as QC
+
+import           Text.Show (Show)
+import           Text.Show.Pretty (ppShow)
+
+
+prop_ap :: Property
+prop_ap =
+  gamble (tree $ chooseInt 1 5) $ \x ->
+  gamble (tree $ chooseChar 'a' 'e') $ \y ->
+    law_ap x y
+
+tree :: Jack a -> Jack (Tree a)
+tree =
+  mapTree duplicate
+
+law_ap :: (Show a, Show b, Eq a, Eq b) => Tree a -> Tree b -> Property
+law_ap x y =
+  let
+    s = (,) `fmap` x <*> y
+    t = (,) `fmap` x `ap` y
+  in
+    QC.counterexample "=== Left ===" .
+    QC.counterexample (ppShow s) .
+    QC.counterexample "=== Right ===" .
+    QC.counterexample (ppShow t) $
+      s == t
+
+return []
+tests :: IO Bool
+tests =
+  $(QC.forAllProperties) . QC.quickCheckWithResult $ QC.stdArgs { QC.maxSuccess = 1000 }

--- a/disorder-jack/test/test.hs
+++ b/disorder-jack/test/test.hs
@@ -1,0 +1,11 @@
+import           Disorder.Core.Main
+
+import qualified Test.Disorder.Jack.Shrink
+import qualified Test.Disorder.Jack.Tree
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.Disorder.Jack.Shrink.tests
+    , Test.Disorder.Jack.Tree.tests
+    ]

--- a/framework/master.toml
+++ b/framework/master.toml
@@ -4,33 +4,40 @@
   sha1 = "4fd979c87b2dfd7d8909ae052f3aeb66939b4bc2"
 
 [build.dist]
-  GHC_VERSION="7.10.2"
+  GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
+  MAFIA_HAPPY = "true"
 
 [build.dist-7-8]
   GHC_VERSION = "7.8.4"
   CABAL_VERSION = "1.22.4.0"
+  MAFIA_HAPPY = "true"
 
 [build.branches-7-8]
   GHC_VERSION = "7.8.4"
   CABAL_VERSION = "1.22.4.0"
+  MAFIA_HAPPY = "true"
 
 [build.dist-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
   GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
+  MAFIA_HAPPY = "true"
 
 [build.branches-7-10]
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
   GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
+  MAFIA_HAPPY = "true"
 
 [build.dist-8-0]
   GHC_VERSION = "8.0.1"
   CABAL_VERSION = "1.24.0.0"
+  MAFIA_HAPPY = "true"
 
 [build.branches-8-0]
   GHC_VERSION = "8.0.1"
   CABAL_VERSION = "1.24.0.0"
+  MAFIA_HAPPY = "true"


### PR DESCRIPTION
![](http://www.wga.hu/art/q/quast/gambling.jpg)

> Jack's love of dice has brought him here, where he has taken on the form of a Haskell library, in order to help you gamble with your properties.

Jack is an alternative to QuickCheck generators / shrinking. The basic idea is that instead of generating a random value and using a shrinking function after the fact, we generate the random value and all the possible shrinks in a tree.

This has many useful properties, you can easily maintain the invariants of the generator for example. In QuickCheck if you do `choose (100, 200)` and then try to shrink it, it will happily shrink to `0`.

QuickCheck shrinking functions are also invariant, so if you have a shrinker for `Text` you cannot lift it to a shrinker of `Foo` without having a mapping in both directions. This breaks the beautiful applicative syntax that generators can be constructed with. Jack doesn't have this problem, a `Jack Text` can be turned in to a `Jack Foo` using only `fmap`, and your `Foo` will be shrunk for free.

This version is still early days, I'm missing a bunch of combinators that are available in QuickCheck proper and I reserve the right to change the names and behaviour of things as we figure out what works, so use with a little caution.

Here's an example usage of Jack, the sub-terms get shrinking for free, and the `reshrink` function is used to add an additional shrinker on top of this:
```hs
exp :: Int -> Jack Exp
exp n =
  let
    text =
      T.pack <$> arbitrary

    exp0 = [
        Con <$> sizedIntegral
      , Var <$> text
      ]

    expN = [
        Lam <$> text <*> exp (n-1)
      , App <$> exp (n-1) <*> exp (n-1)
      ]

    shrink = \case
      Lam _ x ->
        [x]
      App x y ->
        [x, y]
      _ ->
        []
  in
    reshrink shrink $
      oneof (exp0 <> if n > 0 then expN else [])
```

/cc @charleso @thumphries @nhibberd @markhibberd 