### PR TITLE
Make Jack a drop-in replacement for QuickCheck in many cases

### DIFF
--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -13,7 +13,6 @@ description:           disorder-jack.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , ambiata-disorder-core
                      , comonad                         >= 4.2        && < 5.1
                      , containers                      >= 0.4        && < 0.6
                      , deepseq                         >= 1.2        && < 1.5
@@ -42,6 +41,8 @@ library
                        Disorder.Jack.Shrink
                        Disorder.Jack.Tree
 
+                       Test.QuickCheck.Jack
+
 test-suite test
   type:                exitcode-stdio-1.0
 
@@ -60,8 +61,10 @@ test-suite test
                      , ambiata-disorder-core
                      , ambiata-disorder-jack
                      , comonad                         >= 4.2        && < 5.1
+                     , containers                      >= 0.4        && < 0.6
                      , pretty-show                     >= 1.6        && < 1.7
                      , QuickCheck                      >= 2.8.2      && < 2.9
                      , quickcheck-instances            == 0.3.*
+                     , semigroups                      >= 0.16       && < 0.19
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.3        && < 0.6

--- a/disorder-jack/src/Disorder/Jack/Combinators.hs
+++ b/disorder-jack/src/Disorder/Jack/Combinators.hs
@@ -1,42 +1,74 @@
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Disorder.Jack.Combinators (
-    arbitrary
+  -- * Shrink Modifiers
+    noShrink
 
+  -- * Size Combinators
+  , variant
   , sized
+  , resize
+
+  -- * Sized Generators
   , sizedInt
   , sizedIntegral
   , sizedNat
   , sizedNatural
+  , sizedBounded
 
-  , chooseChar
+  -- * Bounded Generators
+  , bounded
+  , boundedInt
+  , boundedEnum
+
+  -- * Range Generators
+  , choose
   , chooseInt
-  , chooseIntegral
+  , chooseChar
 
+  -- * List Combinators
   , oneof
+  , frequency
   , elements
-  , list
-  , list1
-  , vector
+  , sublistOf
+  , shuffle
+  , listOf
+  , listOf1
+  , listOfN
+  , vectorOf
+
+  -- * Uncertainty Combinators
+  , justOf
+  , suchThat
+  , suchThatMaybe
+
+  -- * QuickCheck Compatibility
+  , arbitrary
   ) where
 
 import           Control.Monad (replicateM)
 import           Control.Applicative (Applicative(..))
 
-import           Data.Bool (not)
+import           Data.Bool (Bool(..), not)
 import           Data.Char (Char, ord, chr)
-import           Data.Function (($), (.))
-import           Data.Functor (Functor(..))
+import           Data.Function (($), (.), id)
+import           Data.Functor (Functor(..), (<$>))
 import           Data.Int (Int)
 import qualified Data.List as List
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Maybe (Maybe(..), isJust)
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord(..))
+import           Data.Tuple (fst)
 
 import           Disorder.Jack.Core
 import           Disorder.Jack.Shrink
 import           Disorder.Jack.Tree
 
-import           Prelude (Num(..), Integral, min, max)
+import           Prelude (Num(..), Bounded(..), Enum(..), Integral)
 import qualified Prelude as Savage
 
 import           System.Random (Random)
@@ -44,15 +76,30 @@ import           System.Random (Random)
 import qualified Test.QuickCheck as QC
 
 
--- | Construct a 'Jack' using a type's QuickCheck 'QC.Arbitrary' instance.
-arbitrary :: QC.Arbitrary a => Jack a
-arbitrary =
-  mkJack QC.shrink QC.arbitrary
+-- | Prevent a 'Jack' from shrinking.
+noShrink :: Jack a -> Jack a
+noShrink =
+  mapTree $ \(Node x _) ->
+    Node x []
+
+-- | Modifies a generator using an integer seed.
+variant :: Integral n => n -> Jack a -> Jack a
+variant =
+  mapGen . QC.variant
 
 -- | Construct a 'Jack' that depends on the size parameter.
 sized :: (Int -> Jack a) -> Jack a
 sized f =
   Jack $ QC.sized (runJack . f)
+
+-- | Overrides the size parameter. Returns a 'Jack' which uses the given size
+--   instead of the runtime-size parameter.
+resize :: Int -> Jack a -> Jack a
+resize n =
+  if n < 0 then
+    Savage.error "Disorder.Jack.Combinators.resize: negative size"
+  else
+    mapGen $ QC.resize n
 
 -- | Generates an 'Int'. The number can be positive or negative and its maximum
 --   absolute value depends on the size parameter.
@@ -78,19 +125,37 @@ sizedNatural :: Integral a => Jack a
 sizedNatural =
   mkJack QC.shrinkIntegral QC.arbitrarySizedNatural
 
--- | Generates a 'Char' in the given range.
-chooseChar :: Char -> Char -> Jack Char
-chooseChar b0 b1 =
-  fmap chr $ chooseIntegral (ord b0) (ord b1)
+-- | Generates an integral number from a bounded domain. The number is chosen
+--   from the entire range of the type, but small numbers are generated more
+--   often than big numbers.
+sizedBounded :: (Bounded a, Integral a) => Jack a
+sizedBounded =
+  mkJack QC.shrinkIntegral QC.arbitrarySizedBoundedIntegral
 
--- | Generates an 'Int' in the given range.
-chooseInt :: Int -> Int -> Jack Int
-chooseInt =
-  chooseIntegral
+-- | Generates an integral number. The number is chosen from the entire range
+--   of the type.
+bounded :: (Bounded a, Random a, Integral a) => Jack a
+bounded =
+  mkJack (shrinkTowards 0) $ QC.choose (minBound, maxBound)
+
+-- | Generates an 'Int'. The number is chosen from the entire range of valid
+--   'Int' values, on 64-bit GHC this is [-2^63, 2^63).
+boundedInt :: Jack Int
+boundedInt =
+  bounded
+
+-- | Generates an element from a bounded enumeration.
+boundedEnum :: forall a. (Bounded a, Enum a) => Jack a
+boundedEnum =
+  let
+    e_min = minBound :: a
+    e_max = maxBound :: a
+  in
+    fmap toEnum $ chooseInt (fromEnum e_min, fromEnum e_max)
 
 -- | Generates an integral number in the given range.
-chooseIntegral :: (Random a, Integral a) => a -> a -> Jack a
-chooseIntegral b0 b1 =
+choose :: (Random a, Integral a) => (a, a) -> Jack a
+choose (b0, b1) =
   let
     b_min =
       min b0 b1
@@ -98,17 +163,50 @@ chooseIntegral b0 b1 =
     b_max =
       max b0 b1
   in
-    mkJack (shrinkIntegral b_min) $ QC.choose (b_min, b_max)
+    mkJack (shrinkTowards b_min) $ QC.choose (b_min, b_max)
 
--- | Randomly selects one of jacks in the list.
+-- | Generates an 'Int' in the given range.
+chooseInt :: (Int, Int) -> Jack Int
+chooseInt =
+  choose
+
+-- | Generates a 'Char' in the given range.
+chooseChar :: (Char, Char) -> Jack Char
+chooseChar (b0, b1) =
+  fmap chr $ choose (ord b0, ord b1)
+
+-- | Randomly selects one of the jacks in the list.
 --   /The input list must be non-empty./
 oneof :: [Jack a] -> Jack a
 oneof = \case
   [] ->
     Savage.error "Disorder.Jack.Combinators.oneof: used with empty list"
   xs -> do
-    n <- chooseInt 0 (List.length xs - 1)
+    n <- choose (0, List.length xs - 1)
     xs List.!! n
+
+-- | Uses a weighted distribution to randomly select one of the jacks in the list.
+--   /The input list must be non-empty./
+frequency :: [(Int, Jack a)] -> Jack a
+frequency = \case
+  [] ->
+    Savage.error "Disorder.Jack.Combinators.frequency: used with empty list"
+  xs0 -> do
+    let
+      pick n = \case
+        [] ->
+          Savage.error "Disorder.Jack.Combinators.frequency/pick: used with empty list"
+        (k, x) : xs ->
+          if n <= k then
+            x
+          else
+            pick (n - k) xs
+
+      total =
+        List.sum (fmap fst xs0)
+
+    n <- choose (1, total)
+    pick n xs0
 
 -- | Randomly selects one of the values in the list.
 --   /The input list must be non-empty./
@@ -117,13 +215,35 @@ elements = \case
   [] ->
     Savage.error "Disorder.Jack.Combinators.elements: used with empty list"
   xs -> do
-    n <- chooseInt 0 (List.length xs - 1)
+    n <- choose (0, List.length xs - 1)
     pure $ xs List.!! n
+
+-- | Generates a random subsequence of the given list.
+sublistOf :: [a] -> Jack [a]
+sublistOf =
+  Jack . fmap (unfoldTree id shrinkList) . QC.sublistOf
+
+-- | Generates a random permutation of the given list.
+--
+--   This shrinks towards the order of the list being identical to the input
+--   list.
+--
+shuffle :: [a] -> Jack [a]
+shuffle = \case
+  [] ->
+    pure []
+  xs0 -> do
+    n <- choose (0, List.length xs0 - 1)
+    case List.splitAt n xs0 of
+      (xs, y : ys) ->
+        (y :) <$> shuffle (xs <> ys)
+      (_, []) ->
+        Savage.error "Disorder.Jack.Combinators.shuffle: internal error, split generated empty list"
 
 -- | Generates a list of random length. The maximum length depends on the size
 --   parameter.
-list :: Jack a -> Jack [a]
-list jack =
+listOf :: Jack a -> Jack [a]
+listOf jack =
   sized $ \n -> do
     Jack $ do
       k <- QC.choose (0, n)
@@ -131,8 +251,8 @@ list jack =
 
 -- | Generates a non-empty list of random length. The maximum length depends on
 --   the size parameter.
-list1 :: Jack a -> Jack (NonEmpty a)
-list1 jack =
+listOf1 :: Jack a -> Jack (NonEmpty a)
+listOf1 jack =
   sized $ \n -> do
     Jack $ do
       k <- QC.choose (1, max n 1)
@@ -151,7 +271,82 @@ list1 jack =
 
       fmap go . replicateM k $ runJack jack
 
+-- | Generates a list between 'n' and 'm' in length.
+listOfN :: Int -> Int -> Jack a -> Jack [a]
+listOfN n m (Jack gen) =
+  Jack $ do
+    k <- QC.choose (n, m)
+
+    let
+      k_min =
+        min n m
+
+      check xs =
+        List.length xs >= k_min
+
+    fmap (filterTree check . sequenceShrinkList) $
+      replicateM k gen
+
 -- | Generates a list of the given length.
-vector :: Int -> Jack a -> Jack [a]
-vector n =
+vectorOf :: Int -> Jack a -> Jack [a]
+vectorOf n =
   mapGen (fmap sequenceShrinkOne . replicateM n)
+
+-- | Runs a generator that produces 'Maybe a' until it produces a 'Just'.
+justOf :: Jack (Maybe a) -> Jack a
+justOf g = do
+  mx <- suchThat g isJust
+  case mx of
+    Just x ->
+      pure x
+    Nothing ->
+      Savage.error "Disorder.Jack.Combinators.justOf: internal error, unexpected Nothing"
+
+-- | Generates a value that satisfies a predicate.
+suchThat :: Jack a -> (a -> Bool) -> Jack a
+suchThat (Jack gen) p =
+  Jack $
+    let
+      loop = do
+        mx <- tryGen gen p
+        case mx of
+          Just x ->
+            pure x
+          Nothing ->
+            QC.sized $ \n ->
+              QC.resize (n + 1) loop
+    in
+      loop
+
+-- | Tries to generate a value that satisfies a predicate.
+suchThatMaybe :: Jack a -> (a -> Bool) -> Jack (Maybe a)
+suchThatMaybe (Jack gen) p =
+  Jack $ do
+    mx <- tryGen gen p
+    case mx of
+      Nothing ->
+        pure (pure Nothing)
+      Just x ->
+        pure (fmap Just x)
+
+-- More or less the same logic as suchThatMaybe from QuickCheck, except
+-- modified to ensure that the shrinks also obey the predicate.
+tryGen :: QC.Gen (Tree a) -> (a -> Bool) -> QC.Gen (Maybe (Tree a))
+tryGen gen p =
+  let
+    try k = \case
+      0 ->
+        pure Nothing
+      n -> do
+        x <- QC.resize (2 * k + n) gen
+        if p (outcome x) then
+          pure . Just $ filterTree p x
+        else
+          try (k + 1) (n - 1)
+  in
+    QC.sized $ try 0 . max 1
+
+-- | Construct a 'Jack' using a type's QuickCheck 'QC.Arbitrary' instance.
+arbitrary :: QC.Arbitrary a => Jack a
+arbitrary =
+  mkJack QC.shrink QC.arbitrary

--- a/disorder-jack/src/Test/QuickCheck/Jack.hs
+++ b/disorder-jack/src/Test/QuickCheck/Jack.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+-- | Can be used as a drop-in replacement for "Test.QuickCheck" in some cases.
+module Test.QuickCheck.Jack (
+    Gen
+  , forAll
+  , arbitraryBoundedEnum
+  , module X
+  ) where
+
+import           Disorder.Jack as X
+
+import           Prelude (Bounded, Enum)
+
+import           Text.Show (Show)
+
+import           Test.QuickCheck as X (Arbitrary)
+
+
+type Gen =
+  Jack
+
+forAll :: (Show a, Testable prop) => Gen a -> (a -> prop) -> Property
+forAll =
+  gamble
+
+arbitraryBoundedEnum :: (Bounded a, Enum a) => Jack a
+arbitraryBoundedEnum =
+  boundedEnum

--- a/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Combinators where
+
+import           Control.Applicative (Applicative(..))
+import           Control.Comonad (duplicate)
+import           Control.Monad (Monad(..))
+
+import           Data.Bool (Bool(..), (&&))
+import           Data.Char (Char)
+import           Data.Eq (Eq(..))
+import qualified Data.Foldable as Foldable
+import           Data.Function (($), (.), flip)
+import           Data.Int (Int)
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Ord (Ord(..))
+import qualified Data.Set as Set
+
+import           Disorder.Jack.Combinators
+import           Disorder.Jack.Core
+import           Disorder.Jack.Property
+import           Disorder.Jack.Tree
+
+import           Prelude (even)
+
+import           System.IO (IO)
+
+
+prop_noShrink :: Property
+prop_noShrink =
+  gamble (mapTree duplicate $ noShrink boundedInt) $ \(Node _ xs) ->
+    List.null xs
+
+prop_choose :: Property
+prop_choose =
+  gamble boundedInt $ \n ->
+  gamble boundedInt $ \m ->
+  gamble (mapTree duplicate $ chooseInt (n, m)) $ \xs ->
+    let
+      x_min =
+        min n m
+
+      x_max =
+        max n m
+
+      valid x =
+        x >= x_min && x <= x_max
+    in
+      -- it takes an enormous amount of time to expore the entire shrink space,
+      -- so we just check the first 1000 in a depth first search of the tree
+      List.all valid . List.take 1000 $ Foldable.toList xs
+
+prop_oneof :: Property
+prop_oneof =
+  gamble (mapTree duplicate $ oneof [pure 'A', pure 'B', pure 'C']) isABC
+
+prop_elements :: Property
+prop_elements =
+  gamble (mapTree duplicate $ elements ['A', 'B', 'C']) isABC
+
+prop_frequency :: Property
+prop_frequency =
+  gamble (mapTree duplicate $ frequency [(1, pure 'A'), (1, pure 'B'), (1, pure 'C')]) isABC
+
+isABC :: Tree Char -> Bool
+isABC (Node x xs) =
+  case x of
+    'A' ->
+      List.null xs
+    'B' ->
+      xs == [
+          Node 'A' []
+        ]
+    _ ->
+      xs == [
+          Node 'A' []
+        , Node 'B' [Node 'A' []]
+        ]
+
+prop_sublistOf :: Property
+prop_sublistOf =
+  let
+    xs = Set.fromList "abcdef"
+  in
+    gamble (sublistOf $ Set.toList xs) $ \(ys :: [Char]) ->
+      List.all (flip Set.member xs) ys
+
+prop_shuffle :: Property
+prop_shuffle =
+  gamble (shuffle "abcdef") $ \(xs :: [Char]) ->
+    List.sort xs == "abcdef"
+
+prop_listOf1 :: Property
+prop_listOf1 =
+  gamble (mapTree duplicate . listOf1 $ pure "x") $
+    -- This might seem silly, but we're really just testing that the "internal
+    -- error" case doesn't come up.
+    List.all (\xs -> NonEmpty.length xs > 0) . List.take 1000 . Foldable.toList
+
+prop_vectorOf :: Property
+prop_vectorOf =
+  gamble (choose (0, 1000)) $ \n ->
+  gamble (mapTree duplicate . vectorOf n $ pure "x") $
+    Foldable.all (\xs -> n == List.length xs)
+
+prop_suchThat :: Property
+prop_suchThat =
+  gamble (mapTree duplicate $ bounded `suchThat` even) $ \(xs :: Tree Int) ->
+    List.all even . List.take 1000 $ Foldable.toList xs
+
+return []
+tests :: IO Bool
+tests =
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 100 }

--- a/disorder-jack/test/Test/Disorder/Jack/Minimal.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Minimal.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Minimal where
+
+import           Control.Applicative (Applicative(..), Alternative(..))
+import           Control.Comonad (duplicate)
+import           Control.Monad (Monad(..))
+
+import           Data.Bool (Bool(..), (&&))
+import           Data.Foldable (foldl)
+import           Data.Function (($), (.))
+import           Data.Functor (Functor(..), (<$>))
+import           Data.Int (Int)
+import qualified Data.List as List
+import           Data.Maybe (Maybe(..))
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord(..))
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Disorder.Jack.Combinators
+import           Disorder.Jack.Core
+import           Disorder.Jack.Property
+import           Disorder.Jack.Tree
+
+import           Prelude (Num(..))
+
+import           System.IO (IO)
+
+import           Text.Show (Show)
+import           Text.Show.Pretty (ppShow)
+
+
+data Exp =
+    Var !Text
+  | Con !Int
+  | Lam !Text !Exp
+  | App !Exp !Exp
+    deriving (Show)
+
+exp :: Int -> Jack Exp
+exp n =
+  let
+    text =
+      T.pack <$> arbitrary
+
+    exp0 = [
+        Con <$> sizedIntegral
+      , Var <$> text
+      ]
+
+    expN = [
+        Lam <$> text <*> exp (n-1)
+      , App <$> exp (n-1) <*> exp (n-1)
+      ]
+
+    shrink = \case
+      Lam _ x ->
+        [x]
+      App x y ->
+        [x, y]
+      _ ->
+        []
+  in
+    reshrink shrink $
+      oneof (exp0 <> if n > 0 then expN else [])
+
+noAppCon10 :: Exp -> Bool
+noAppCon10 = \case
+  Con _ ->
+    True
+  Var _ ->
+    True
+  Lam _ x ->
+    noAppCon10 x
+  App _ (Con 10) ->
+    False
+  App x1 x2 ->
+    noAppCon10 x1 && noAppCon10 x2
+
+smallestFailure :: (a -> Bool) -> Tree a -> Maybe a
+smallestFailure f (Node x xs) =
+  if f x then
+    Nothing
+  else
+    foldl (<|>) empty (fmap (smallestFailure f) xs) <|> Just x
+
+prop_listOf_minimal :: Property
+prop_listOf_minimal =
+  gamble (mapTree duplicate . listOf $ sized exp) $ \xs ->
+    case smallestFailure (List.all noAppCon10) xs of
+      Nothing ->
+        property succeeded
+      -- The tree must be organised such that smallest fail is found by greedy
+      -- traversal with a predicate.
+      Just [App (Con 0) (Con 10)] ->
+        property succeeded
+      Just x ->
+        counterexample "" .
+        counterexample "Greedy traversal with predicate did not yield the minimal shrink." .
+        counterexample "" .
+        counterexample "=== Minimal ===" .
+        counterexample (ppShow [App (Con 0) (Con 10)]) .
+        counterexample "=== Actual ===" .
+        counterexample (ppShow x) $
+        property failed
+
+return []
+tests :: IO Bool
+tests =
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 100 }

--- a/disorder-jack/test/Test/Disorder/Jack/Shrink.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Shrink.hs
@@ -1,116 +1,46 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Disorder.Jack.Shrink where
 
-import           Control.Applicative (Applicative(..), Alternative(..))
-import           Control.Comonad (duplicate)
 import           Control.Monad (Monad(..))
 
 import           Data.Bool (Bool(..), (&&))
-import           Data.Foldable (foldl)
+import           Data.Eq (Eq(..))
 import           Data.Function (($), (.))
-import           Data.Functor (Functor(..), (<$>))
-import           Data.Int (Int)
 import qualified Data.List as List
-import           Data.Maybe (Maybe(..))
-import           Data.Monoid ((<>))
-import           Data.Ord (Ord(..))
-import           Data.Text (Text)
-import qualified Data.Text as T
+import           Data.Ord (Ord(..), min, max)
 
 import           Disorder.Jack.Combinators
-import           Disorder.Jack.Core
 import           Disorder.Jack.Property
-import           Disorder.Jack.Tree
-
-import           Prelude (Num(..))
+import           Disorder.Jack.Shrink
 
 import           System.IO (IO)
 
-import qualified Test.QuickCheck as QC
-import qualified Test.QuickCheck.Property as QC
 
-import           Text.Show (Show)
-import           Text.Show.Pretty (ppShow)
+prop_shrinkTowards_unique :: Property
+prop_shrinkTowards_unique =
+  gamble boundedInt $ \x ->
+  gamble boundedInt $ \y ->
+    let
+      ss = shrinkTowards x y
+    in
+      List.nub ss == ss
 
-
-data Exp =
-    Var !Text
-  | Con !Int
-  | Lam !Text !Exp
-  | App !Exp !Exp
-    deriving (Show)
-
-exp :: Int -> Jack Exp
-exp n =
-  let
-    text =
-      T.pack <$> arbitrary
-
-    exp0 = [
-        Con <$> sizedIntegral
-      , Var <$> text
-      ]
-
-    expN = [
-        Lam <$> text <*> exp (n-1)
-      , App <$> exp (n-1) <*> exp (n-1)
-      ]
-
-    shrink = \case
-      Lam _ x ->
-        [x]
-      App x y ->
-        [x, y]
-      _ ->
-        []
-  in
-    reshrink shrink $
-      oneof (exp0 <> if n > 0 then expN else [])
-
-noAppCon10 :: Exp -> Bool
-noAppCon10 = \case
-  Con _ ->
-    True
-  Var _ ->
-    True
-  Lam _ x ->
-    noAppCon10 x
-  App _ (Con 10) ->
-    False
-  App x1 x2 ->
-    noAppCon10 x1 && noAppCon10 x2
-
-smallestFailure :: (a -> Bool) -> Tree a -> Maybe a
-smallestFailure f (Node x xs) =
-  if f x then
-    Nothing
-  else
-    foldl (<|>) empty (fmap (smallestFailure f) xs) <|> Just x
-
-prop_jack :: Property
-prop_jack =
-  gamble (mapTree duplicate . list $ sized exp) $ \xs ->
-    case smallestFailure (List.all noAppCon10) xs of
-      Nothing ->
-        property QC.succeeded
-      -- The tree must be organised such that smallest fail is found by greedy
-      -- traversal with a predicate.
-      Just [App (Con 0) (Con 10)] ->
-        property QC.succeeded
-      Just x ->
-        QC.counterexample "" .
-        QC.counterexample "Greedy traversal with predicate did not yield the minimal shrink." .
-        QC.counterexample "" .
-        QC.counterexample "=== Minimal ===" .
-        QC.counterexample (ppShow [App (Con 0) (Con 10)]) .
-        QC.counterexample "=== Actual ===" .
-        QC.counterexample (ppShow x) $
-        property QC.failed
+prop_shrinkTowards_range :: Property
+prop_shrinkTowards_range =
+  gamble boundedInt $ \x ->
+  gamble boundedInt $ \y ->
+    let
+      s_min = min x y
+      s_max = max x y
+      valid s =
+        s >= s_min && s <= s_max
+    in
+      List.all valid $ shrinkTowards x y
 
 return []
 tests :: IO Bool
 tests =
-  $(QC.forAllProperties) . QC.quickCheckWithResult $
-    QC.stdArgs { QC.maxSuccess = 100 }
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 100 }

--- a/disorder-jack/test/Test/Disorder/Jack/Tree.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Tree.hs
@@ -18,20 +18,18 @@ import           Disorder.Jack.Tree
 
 import           System.IO (IO)
 
-import qualified Test.QuickCheck as QC
-
 import           Text.Show (Show)
 import           Text.Show.Pretty (ppShow)
 
 
 prop_ap :: Property
 prop_ap =
-  gamble (tree $ chooseInt 1 5) $ \x ->
-  gamble (tree $ chooseChar 'a' 'e') $ \y ->
+  gamble (treeOf $ chooseInt (1, 5)) $ \x ->
+  gamble (treeOf $ chooseChar ('a', 'e')) $ \y ->
     law_ap x y
 
-tree :: Jack a -> Jack (Tree a)
-tree =
+treeOf :: Jack a -> Jack (Tree a)
+treeOf =
   mapTree duplicate
 
 law_ap :: (Show a, Show b, Eq a, Eq b) => Tree a -> Tree b -> Property
@@ -40,13 +38,13 @@ law_ap x y =
     s = (,) `fmap` x <*> y
     t = (,) `fmap` x `ap` y
   in
-    QC.counterexample "=== Left ===" .
-    QC.counterexample (ppShow s) .
-    QC.counterexample "=== Right ===" .
-    QC.counterexample (ppShow t) $
+    counterexample "=== Left ===" .
+    counterexample (ppShow s) .
+    counterexample "=== Right ===" .
+    counterexample (ppShow t) $
       s == t
 
 return []
 tests :: IO Bool
 tests =
-  $(QC.forAllProperties) . QC.quickCheckWithResult $ QC.stdArgs { QC.maxSuccess = 1000 }
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 1000 }

--- a/disorder-jack/test/test.hs
+++ b/disorder-jack/test/test.hs
@@ -1,11 +1,15 @@
 import           Disorder.Core.Main
 
+import qualified Test.Disorder.Jack.Combinators
+import qualified Test.Disorder.Jack.Minimal
 import qualified Test.Disorder.Jack.Shrink
 import qualified Test.Disorder.Jack.Tree
 
 main :: IO ()
 main =
   disorderMain [
-      Test.Disorder.Jack.Shrink.tests
+      Test.Disorder.Jack.Combinators.tests
+    , Test.Disorder.Jack.Minimal.tests
+    , Test.Disorder.Jack.Shrink.tests
     , Test.Disorder.Jack.Tree.tests
     ]


### PR DESCRIPTION
This adds most of the missing combinators which are in QuickCheck, and some from disorder-core which have been re-implemented to shrink more nicely. It also renames some existing combinators to be the same as in QuickCheck so that it's easier to switch between the two.

Not sure if I've overreached with the re-exports in `Disorder.Jack.Property`, but it does mean that in most cases you can just import `Disorder.Jack` and not need `Test.QuickCheck` at all. This is useful because we can override the QuickCheck behaviour to be more Jack specific and most of the QuickCheck functions are replaced by Jack ones anyway.

This also adds a compatibility module `Test.QuickCheck.Jack` (not sure on naming) which remaps `gamble` to `forAll` and `Jack a` to `Gen a` so that you can alternate between QuickCheck and Jack by just adding and removing `.Jack`. The only place this won't work is defining `Arbitrary` instances, you'll need a qualified import of `Arbitrary` for that.

/cc @charleso @thumphries @markhibberd 