### PR TITLE
Add general tripping combinator to Jack which uses ppShow by default

### DIFF
--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -40,6 +40,7 @@ library
                        Disorder.Jack.Property
                        Disorder.Jack.Shrink
                        Disorder.Jack.Tree
+                       Disorder.Jack.Tripping
 
                        Test.QuickCheck.Jack
 

--- a/disorder-jack/src/Disorder/Jack.hs
+++ b/disorder-jack/src/Disorder/Jack.hs
@@ -8,3 +8,4 @@ import           Disorder.Jack.Core as X
 import           Disorder.Jack.Property as X
 import           Disorder.Jack.Shrink as X
 import           Disorder.Jack.Tree as X
+import           Disorder.Jack.Tripping as X

--- a/disorder-jack/src/Disorder/Jack/Tripping.hs
+++ b/disorder-jack/src/Disorder/Jack/Tripping.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Disorder.Jack.Tripping (
+    tripping
+  , trippingRender
+  , trippingString
+  ) where
+
+import           Disorder.Jack.Property
+
+import           Control.Applicative (Applicative(..))
+
+import           Data.Eq (Eq(..))
+import           Data.Function (($), (.))
+import           Data.String (String)
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Text.Show (Show(..))
+import           Text.Show.Pretty (ppShow)
+
+
+tripping :: (Applicative f, Eq (f a), Show (f a)) => (a -> b) -> (b -> f a) -> a -> Property
+tripping =
+  trippingString ppShow
+
+trippingRender :: (Applicative f, Eq (f a)) => (f a -> Text) -> (a -> b) -> (b -> f a) -> a -> Property
+trippingRender render =
+  trippingString (T.unpack . render)
+
+trippingString :: (Applicative f, Eq (f a)) => (f a -> String) -> (a -> b) -> (b -> f a) -> a -> Property
+trippingString render to fro x =
+  let
+    roundtrip =
+      (fro . to) x
+
+    original =
+      pure x
+  in
+    counterexample "" .
+    counterexample "Roundtrip failed." .
+    counterexample "" .
+    counterexample "=== Original ===" .
+    counterexample (render original) .
+    counterexample "" .
+    counterexample "=== Roundtrip ===" .
+    counterexample (render roundtrip) $
+      property (roundtrip == original)

--- a/disorder-jack/test/Test/Disorder/Jack/Tripping.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Tripping.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Tripping where
+
+import           Control.Monad (return)
+
+import           Disorder.Core.Property (neg)
+import           Disorder.Jack
+
+import           Data.Bool (Bool)
+import           Data.Function (($), (.), id, const)
+import           Data.Int (Int)
+import           Data.Maybe (Maybe(..))
+
+import           System.IO (IO)
+
+
+prop_tripping :: Property
+prop_tripping =
+  gamble bounded $
+    tripping id (Just :: Int -> Maybe Int)
+
+prop_tripping_neg :: Property
+prop_tripping_neg =
+  gamble bounded $
+    neg . tripping id (const Nothing :: Int -> Maybe Int)
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll


### PR DESCRIPTION
This is a simplified version of the `tripping` function from `Disorder.Core.Tripping`, but extended with customisable rendering, defaulting to `ppShow`.

I've wanted this in disorder-core for a long time, but because it uses `pretty-show` it would require a dependency on `happy` which would be a bit of a nightmare to force for all projects.

Jack already depends on `pretty-show` and has a bunch of its own QuickCheck combinators, so this seems like a reasonable place for it.

/cc @charleso @erikd-ambiata 