### PR TITLE
Add oneOfRec and maybeOf and some housekeeping

### DIFF
--- a/disorder-jack/README.md
+++ b/disorder-jack/README.md
@@ -42,26 +42,12 @@ data Exp =
   | App !Exp !Exp
     deriving (Eq, Ord, Show)
 
-exp :: Int -> Jack Exp
-exp n =
+exp :: Jack Exp
+exp =
   let
-    text :: Jack Text
     text =
       T.pack <$> arbitrary
 
-    exp0 :: Jack Exp
-    exp0 = [
-        Con <$> sizedIntegral
-      , Var <$> text
-      ]
-
-    expN :: Jack Exp
-    expN = [
-        Lam <$> text <*> exp (n-1)
-      , App <$> exp (n-1) <*> exp (n-1)
-      ]
-
-    shrink :: Exp -> [Exp]
     shrink = \case
       Lam _ x ->
         [x]
@@ -71,7 +57,13 @@ exp n =
         []
   in
     reshrink shrink $
-      oneof (exp0 <> if n > 0 then expN else [])
+      oneOfRec [
+          Con <$> sizedIntegral
+        , Var <$> text
+        ] [
+          Lam <$> text <*> exp
+        , App <$> exp <*> exp
+        ]
 ```
 
 ## Properties

--- a/disorder-jack/src/Test/QuickCheck/Jack.hs
+++ b/disorder-jack/src/Test/QuickCheck/Jack.hs
@@ -4,10 +4,17 @@ module Test.QuickCheck.Jack (
     Gen
   , forAll
   , arbitraryBoundedEnum
+  , oneof
+  , listOf1
   , module X
   ) where
 
-import           Disorder.Jack as X
+import qualified Disorder.Jack as Jack
+import           Disorder.Jack as X hiding (listOf1)
+
+import           Data.Function ((.))
+import           Data.Functor (fmap)
+import           Data.Foldable (toList)
 
 import           Prelude (Bounded, Enum)
 
@@ -26,3 +33,11 @@ forAll =
 arbitraryBoundedEnum :: (Bounded a, Enum a) => Jack a
 arbitraryBoundedEnum =
   boundedEnum
+
+oneof :: [Jack a] -> Jack a
+oneof =
+  oneOf
+
+listOf1 :: Jack a -> Jack [a]
+listOf1 =
+  fmap toList . Jack.listOf1

--- a/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
@@ -55,7 +55,7 @@ prop_choose =
 
 prop_oneof :: Property
 prop_oneof =
-  gamble (mapTree duplicate $ oneof [pure 'A', pure 'B', pure 'C']) isABC
+  gamble (mapTree duplicate $ oneOf [pure 'A', pure 'B', pure 'C']) isABC
 
 prop_elements :: Property
 prop_elements =


### PR DESCRIPTION
This adds a two new combinators:

- `oneOfRec` for working with recursive types which reduces the size when recursion occurs - this is probably not the last word on this, it's still a little unsatisfying I think. It's in disorder core as `oneofSized`.
- `maybeOf` which generates a `Nothing` some of the time - a variation of this is in disorder-core as `maybeGen`.

A few clean ups too, I renamed `oneof` to `oneOf` so that the API is more consistent. For compatibility I exported `oneof` as an alias in `Test.QuickCheck.Jack`, as well as changing the type of `listOf1` in `Test.QuickCheck.Jack` to a list for compatibility.

/cc @amosr @charleso @thumphries 