### PR TITLE
Show value diffs for counterexamples

### DIFF
--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -38,6 +38,7 @@ library
                        Disorder.Jack.Combinators
                        Disorder.Jack.Core
                        Disorder.Jack.Property
+                       Disorder.Jack.Property.Diff
                        Disorder.Jack.Shrink
                        Disorder.Jack.Tree
                        Disorder.Jack.Tripping

--- a/disorder-jack/src/Disorder/Jack/Property.hs
+++ b/disorder-jack/src/Disorder/Jack/Property.hs
@@ -138,6 +138,7 @@ infix 4 ===
 
 (===) :: (Eq a, Show a) => a -> a -> Property
 (===) x y =
+  counterexample "=== Not equal ===" $
   counterexample renderDiff (x == y)
   where
     renderDiff

--- a/disorder-jack/src/Disorder/Jack/Property.hs
+++ b/disorder-jack/src/Disorder/Jack/Property.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternGuards #-}
 module Disorder.Jack.Property (
     gamble
   , gambleRender
@@ -46,23 +47,18 @@ module Disorder.Jack.Property (
   , forAllProperties
   ) where
 
-import           Data.Eq (Eq(..))
 import           Data.Foldable (for_, traverse_)
-import           Data.Function (($), (.))
-import           Data.Functor (Functor(..))
 import qualified Data.List as List
 import           Data.Monoid ((<>))
-import           Data.String (String)
 import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Disorder.Jack.Core
 import           Disorder.Jack.Tree
 
-import           System.IO (IO, putStrLn)
-
-import           Text.Show (Show)
 import           Text.Show.Pretty (ppShow)
+import qualified Text.Show.Pretty as Pretty
+import           Prelude
 
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck.All (quickCheckAll, verboseCheckAll, forAllProperties)
@@ -142,4 +138,80 @@ infix 4 ===
 
 (===) :: (Eq a, Show a) => a -> a -> Property
 (===) x y =
-  counterexample (ppShow x <> " /= " <> ppShow y) (x == y)
+  counterexample renderDiff (x == y)
+  where
+    renderDiff
+     | Just x' <- Pretty.reify x
+     , Just y' <- Pretty.reify y
+     = renderDiffs x' y'
+     | otherwise
+     = ppShow x <> " /= " <> ppShow y
+
+-- | Attempt to render difference between two MaxML values
+renderDiffs :: Pretty.Value -> Pretty.Value -> String
+renderDiffs val1 val2 = go 0 val1 val2
+ where
+  go i a b = case (a, b) of
+    _
+     -- If values are same, render normally
+     | a == b
+     -> same i (Pretty.valToStr a)
+     -- If values are different but both fit on one line, just print both
+     | length (List.lines (Pretty.valToStr a)) < 2
+     , length (List.lines (Pretty.valToStr b)) < 2
+     -> ll i a <> rr i b
+
+    -- Both the same constructor with same number of arguments, so check arguments
+    (Pretty.Con m us, Pretty.Con n vs)
+     | n == m
+     , length us == length vs
+     -> same i n <> goes go "" "" "" i (List.zip us vs)
+
+    -- Record constructors, check arguments
+    (Pretty.Rec m us, Pretty.Rec n vs)
+     | n == m
+     , length us == length vs
+     , fmap fst us == fmap fst vs
+     -> same i n
+     -- Print field name too
+     <> goes (\i' (ix,u) (_,v) -> same (i'-1) (ix <> " = ") <> go i' u v) "{" "," "}" i (List.zip us vs)
+
+    -- Tuples and lists of same length
+    (Pretty.Tuple us, Pretty.Tuple vs)
+     | length us == length vs
+     -> goes go "(" "," ")" i (List.zip us vs)
+
+    (Pretty.List us, Pretty.List vs)
+     | length us == length vs
+     -> goes go "[" "," "]" i (List.zip us vs)
+
+    -- Otherwise they are different constructors and we can't descend further, so print both
+    _
+     -> ll i a <> rr i b
+
+  -- Print same
+  same i n = sho " " i n
+  -- Print value on left side
+  ll i v = sho "-" i (Pretty.valToStr v)
+  -- Print value on right side
+  rr i v = sho "+" i (Pretty.valToStr v)
+
+  -- Actually print something
+  sho pre i val
+   = let tabs = List.replicate (i * 2) ' '
+         -- Add the prefix '+' or '-' as well as indentation to each line
+         lns  = List.lines val
+         lns' = fmap (\a -> pre <> tabs <> a) lns
+     in  unlines lns'
+
+  goes gg l m r i uvs
+   = same i l <> goes' False gg m i uvs <> same i r
+
+  goes' putSep gg m i ((u,v):uvs)
+   = let rest = gg (i+1) u v <> goes' True gg m i uvs
+     in if   putSep
+        then same i m <> rest
+        else rest
+  goes' _ _ _ _ []
+   = []
+

--- a/disorder-jack/src/Disorder/Jack/Property.hs
+++ b/disorder-jack/src/Disorder/Jack/Property.hs
@@ -59,12 +59,12 @@ import qualified Data.Text as T
 
 import           Disorder.Jack.Core
 import           Disorder.Jack.Tree
+import           Disorder.Jack.Property.Diff
 import           System.IO (IO, putStrLn)
 
 import           Text.Show (Show)
 import           Text.Show.Pretty (ppShow)
 import qualified Text.Show.Pretty as Pretty
-import           Prelude (Num(..), Ord(..))
 import           Prelude (Bool(..), Maybe(..))
 
 import qualified Test.QuickCheck as QC
@@ -146,106 +146,11 @@ infix 4 ===
 (===) :: (Eq a, Show a) => a -> a -> Property
 (===) x y =
   counterexample "=== Not equal ===" $
-  counterexample renderDiff (x == y)
+  counterexample render (x == y)
   where
-    renderDiff
+    render
      | Just x' <- Pretty.reify x
      , Just y' <- Pretty.reify y
      = renderDiffs x' y'
      | True
      = ppShow x <> " /= " <> ppShow y
-
--- | Attempt to render difference between two MaxML values
-renderDiffs :: Pretty.Value -> Pretty.Value -> String
-renderDiffs val1 val2 = prints $ go 0 val1 val2
- where
-  go i a b = case (a, b) of
-    _
-     -- If values are same, render normally
-     | a == b
-     -> same i (Pretty.valToStr a)
-     -- If values are different but both fit on one line, just print both
-     | List.length (List.lines (Pretty.valToStr a)) < 2
-     , List.length (List.lines (Pretty.valToStr b)) < 2
-     -> ll i a <> rr i b
-
-    -- Both the same constructor with same number of arguments, so check arguments
-    (Pretty.Con m us, Pretty.Con n vs)
-     | n == m
-     , List.length us == List.length vs
-     -> same i n <> goes go "" "" "" i (List.zip us vs)
-
-    -- Record constructors, check arguments
-    (Pretty.Rec m us, Pretty.Rec n vs)
-     | n == m
-     , List.length us == List.length vs
-     , fmap (\(u,_) -> u) us == fmap (\(v,_) -> v) vs
-     -> same i n
-     -- Print field name too
-     <> goes (\i' (ix,u) (_,v) -> same i' (ix <> " = ") <> go i' u v) "{" "," "}" i (List.zip us vs)
-
-    -- Tuples and lists of same length
-    (Pretty.Tuple us, Pretty.Tuple vs)
-     | List.length us == List.length vs
-     -> goes go "(" "," ")" i (List.zip us vs)
-
-    (Pretty.List us, Pretty.List vs)
-     | List.length us == List.length vs
-     -> goes go "[" "," "]" i (List.zip us vs)
-
-    -- Otherwise they are different constructors and we can't descend further, so print both
-    _
-     -> ll i a <> rr i b
-
-  -- Print same
-  same i n = sho " " i n
-  -- Print value on left side
-  ll i v = sho "-" i (Pretty.valToStr v)
-  -- Print value on right side
-  rr i v = sho "+" i (Pretty.valToStr v)
-
-  -- Split up multi-line things into same indentation level.
-  -- Any indentation in the string itself will still be there as spaces.
-  sho pre i val = fmap (\a -> (pre,i,a)) $ List.lines val
-
-  goes gg l m r i uvs
-   = same i l <> goes' False gg m i uvs <> same i r
-
-  goes' putSep gg m i ((u,v):uvs)
-   = let rest = gg (i+1) u v <> goes' True gg m i uvs
-     in if   putSep
-        then same i m <> rest
-        else rest
-  goes' _ _ _ _ []
-   = []
-
-  -- Layout / printing part
-  prints [] = []
-  -- Squash two lines together.
-  -- If the next line is indented more, we might be able to squeeze them onto a single line.
-  -- This looks a bit nicer.
-  -- For example,
-  -- "    ,"
-  -- "       Foo"
-  -- can be condensed onto a single line:
-  -- "    ,  Foo"
-  --
-  prints ((p1,i1,v1):(p2,i2,v2):fs)
-   -- Only if their '+' or '-' prefix are the same
-   | p1 == p2
-   -- Get end of first line
-   , end1   <- i1 * tabSize + List.length v1
-   -- And start of next line
-   , start2 <- i2 * tabSize
-   -- Check end fits before start
-   , end1 < start2
-   -- Now add extra padding that we lost by condensing, to get to second line's indentation level
-   = let diff = start2 - end1
-     in  prints ((p1,i1,v1 <> List.replicate diff ' ' <> v2) : fs)
-
-  -- Indent and append all the bits together
-  prints ((p,i,v):fs)
-   = let tabs = List.replicate (i * tabSize) ' '
-     in  p <> tabs <> v <> "\n" <> prints fs
-
-  tabSize = 2

--- a/disorder-jack/src/Disorder/Jack/Property/Diff.hs
+++ b/disorder-jack/src/Disorder/Jack/Property/Diff.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternGuards #-}
+module Disorder.Jack.Property.Diff (
+    renderDiffs
+  ) where
+
+import           Data.Eq (Eq(..))
+import           Data.Function (($))
+import           Data.Functor (Functor(..))
+import qualified Data.List as List
+import           Data.Monoid ((<>))
+import           Data.String (String)
+
+import qualified Text.Show.Pretty as Pretty
+import           Prelude (Num(..), Ord(..))
+import           Prelude (Bool(..))
+
+
+
+-- | Attempt to render difference between two MaxML values
+renderDiffs :: Pretty.Value -> Pretty.Value -> String
+renderDiffs val1 val2 = prints $ go 0 val1 val2
+ where
+  go i a b = case (a, b) of
+    _
+     -- If values are same, render normally
+     | a == b
+     -> same i (Pretty.valToStr a)
+     -- If values are different but both fit on one line, just print both
+     | List.length (List.lines (Pretty.valToStr a)) < 2
+     , List.length (List.lines (Pretty.valToStr b)) < 2
+     -> ll i a <> rr i b
+
+    -- Both the same constructor with same number of arguments, so check arguments
+    (Pretty.Con m us, Pretty.Con n vs)
+     | n == m
+     , List.length us == List.length vs
+     -> same i n <> goes go "" "" "" i (List.zip us vs)
+
+    -- Record constructors, check arguments
+    (Pretty.Rec m us, Pretty.Rec n vs)
+     | n == m
+     , List.length us == List.length vs
+     , fmap (\(u,_) -> u) us == fmap (\(v,_) -> v) vs
+     -> same i n
+     -- Print field name too
+     <> goes (\i' (ix,u) (_,v) -> same i' (ix <> " =") <> go i' u v) "{" "," "}" i (List.zip us vs)
+
+    -- Tuples and lists of same length
+    (Pretty.Tuple us, Pretty.Tuple vs)
+     | List.length us == List.length vs
+     -> goes go "(" "," ")" i (List.zip us vs)
+
+    (Pretty.List us, Pretty.List vs)
+     | List.length us == List.length vs
+     -> goes go "[" "," "]" i (List.zip us vs)
+
+    -- Otherwise they are different constructors and we can't descend further, so print both
+    _
+     -> ll i a <> rr i b
+
+  -- Print same
+  same i n = sho " " i n
+  -- Print value on left side
+  ll i v = sho "-" i (Pretty.valToStr v)
+  -- Print value on right side
+  rr i v = sho "+" i (Pretty.valToStr v)
+
+  -- Split up multi-line things into same indentation level.
+  -- Any indentation in the string itself will still be there as spaces.
+  sho pre i val = fmap (\a -> (pre,i,a)) $ List.lines val
+
+  goes gg l m r i uvs
+   = same i l <> goes' False gg m i uvs <> same i r
+
+  goes' putSep gg m i ((u,v):uvs)
+   = let rest = gg (i+1) u v <> goes' True gg m i uvs
+     in if   putSep
+        then same i m <> rest
+        else rest
+  goes' _ _ _ _ []
+   = []
+
+  -- Layout / printing part
+  prints [] = []
+  -- Squash two lines together.
+  -- If the next line is indented more, we might be able to squeeze them onto a single line.
+  -- This looks a bit nicer.
+  -- For example,
+  -- "    ,"
+  -- "       Foo"
+  -- can be condensed onto a single line:
+  -- "    ,  Foo"
+  --
+  prints ((p1,i1,v1):(p2,i2,v2):fs)
+   -- Only if their '+' or '-' prefix are the same
+   | p1 == p2
+   -- Get end of first line
+   , end1   <- i1 * tabSize + List.length v1
+   -- And start of next line
+   , start2 <- i2 * tabSize
+   -- Check end fits before start
+   , end1 < start2
+   -- Now add extra padding that we lost by condensing, to get to second line's indentation level
+   = let diff = start2 - end1
+     in  prints ((p1,i1,v1 <> List.replicate diff ' ' <> v2) : fs)
+
+  -- Indent and append all the bits together
+  prints ((p,i,v):fs)
+   = let tabs = List.replicate (i * tabSize) ' '
+     in  p <> tabs <> v <> "\n" <> prints fs
+
+  tabSize = 2

--- a/disorder-jack/test/Test/Disorder/Jack/Property/Diff.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Property/Diff.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+module Test.Disorder.Jack.Property.Diff where
+
+import           Control.Monad (Monad(..))
+
+import           Data.Bool (Bool(..))
+import           Data.Eq (Eq(..))
+import           Data.Function (($), (.))
+import qualified Data.List as List
+import           Data.Maybe (Maybe(..))
+import           Data.Either (Either(..))
+import           Data.String (String)
+
+import           Disorder.Jack
+import           Disorder.Jack.Property.Diff
+
+import           Text.Show (Show(..))
+import qualified Text.Show.Pretty as Pretty
+
+import           Prelude (Int)
+
+import           System.IO (IO)
+
+checkDiff :: Show a => a -> a -> [String] -> Property
+checkDiff left right expect =
+ let Just left'  = Pretty.reify left
+     Just right' = Pretty.reify right
+     actual      = renderDiffs left' right'
+     expect'     = List.unlines expect
+ in  counterexample "=== Left ==="
+   $ counterexample (show left)
+   $ counterexample "=== Right ==="
+   $ counterexample (show right)
+   $ counterexample "=== Expect ==="
+   $ counterexample expect'
+   $ counterexample "=== Actual ==="
+   $ counterexample actual
+   ( actual == expect' )
+
+-- If the difference fits on single line, the outer constructors should appear in diff
+prop_eg1 :: Property
+prop_eg1 =
+  checkDiff
+    (Just 1)
+    (Just 2)
+    [ "-Just 1"
+    , "+Just 2" ]
+
+prop_eg2 :: Property
+prop_eg2 =
+  checkDiff
+    [1,2,3,4]
+    [1,2,3,5]
+    [ "-[ 1 , 2 , 3 , 4 ]"
+    , "+[ 1 , 2 , 3 , 5 ]" ]
+
+-- If we have a big enough list that it won't fit on a single line,
+-- it should dig down into the nested parts to show the diff
+data SomethingLong
+ = SomethingReallyReallyLongThatDontFitOnASingleLine
+ deriving Show
+
+prop_eg3 :: Property
+prop_eg3 =
+  checkDiff
+    [Right SomethingReallyReallyLongThatDontFitOnASingleLine,  Left 4]
+    [Right SomethingReallyReallyLongThatDontFitOnASingleLine,  Left 5]
+    [ " [ Right SomethingReallyReallyLongThatDontFitOnASingleLine"
+    , " ,"
+    , "-  Left 4"
+    , "+  Left 5"
+    , " ]"
+    ]
+
+-- Records show full field names
+data RecordWithFields
+ = RecordWithFields
+ { field1 :: Int
+ , field2 :: Maybe Int
+ , field3 :: [RecordWithFields]
+ }
+ deriving Show
+
+prop_eg4 :: Property
+prop_eg4 =
+  checkDiff
+    (RecordWithFields 0 (Just 1) [RecordWithFields 2 Nothing []])
+    (RecordWithFields 0 Nothing  [RecordWithFields 2 (Just 1) []])
+    [ " RecordWithFields"
+    , " { field1 ="
+    , "   0"
+    , " , field2 ="
+    , "-  Just 1"
+    , "+  Nothing"
+    , " , field3 ="
+    , "   ["
+    , "-    RecordWithFields { field1 = 2 , field2 = Nothing , field3 = [] }"
+    , "+    RecordWithFields { field1 = 2 , field2 = Just 1 , field3 = [] }"
+    , "   ]"
+    , " }"
+    ]
+
+return []
+tests :: IO Bool
+tests =
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 1 }
+

--- a/disorder-jack/test/test.hs
+++ b/disorder-jack/test/test.hs
@@ -2,6 +2,7 @@ import           Disorder.Core.Main
 
 import qualified Test.Disorder.Jack.Combinators
 import qualified Test.Disorder.Jack.Minimal
+import qualified Test.Disorder.Jack.Property.Diff
 import qualified Test.Disorder.Jack.Shrink
 import qualified Test.Disorder.Jack.Tree
 
@@ -10,6 +11,7 @@ main =
   disorderMain [
       Test.Disorder.Jack.Combinators.tests
     , Test.Disorder.Jack.Minimal.tests
+    , Test.Disorder.Jack.Property.Diff.tests
     , Test.Disorder.Jack.Shrink.tests
     , Test.Disorder.Jack.Tree.tests
     ]


### PR DESCRIPTION
This gives a nicer error message for seeing the difference between two values.
It only works if they are valid `Show` instances that can be parsed by `pretty-show`: otherwise it just uses the old `x /= y` style.  
```
=== Not equal ===
 [
   Right
     (
       Entity
       {
       entityHash =
-        EntityHash 0
+        EntityHash 8
       ,
       entityId =
-        EntityId "kyle-000"
+        EntityId "kyle-002"
       ,
       entityAttributes =
         [ Attribute { attributeId = AttributeId 0 , attributeRecords = 1 }
         ]
       }
     ,
       [ [ Index
             { indexTime = Time 12617596800
             , indexPriority = Priority 0
             , indexTombstone = Tombstone
             }
         ]
       ]
     ,
       [ Record [ WordField [ 0 ] ] ]
     )
 ]
```