### PR TITLE
Fix Jack bind implementation

### DIFF
--- a/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Combinators.hs
@@ -95,7 +95,7 @@ prop_shuffle =
 
 prop_listOf1 :: Property
 prop_listOf1 =
-  gamble (mapTree duplicate . listOf1 $ pure "x") $
+  gamble (mapTree duplicate . listOf1 $ pure ("x" :: [Char])) $
     -- This might seem silly, but we're really just testing that the "internal
     -- error" case doesn't come up.
     List.all (\xs -> NonEmpty.length xs > 0) . List.take 1000 . Foldable.toList
@@ -103,7 +103,7 @@ prop_listOf1 =
 prop_vectorOf :: Property
 prop_vectorOf =
   gamble (choose (0, 1000)) $ \n ->
-  gamble (mapTree duplicate . vectorOf n $ pure "x") $
+  gamble (mapTree duplicate . vectorOf n $ pure ("x" :: [Char])) $
     Foldable.all (\xs -> n == List.length xs)
 
 prop_suchThat :: Property

--- a/disorder-jack/test/Test/Disorder/Jack/Core.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Core.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Jack.Core where
+
+import           Control.Applicative (Applicative(..))
+import           Control.Monad (Monad(..), ap)
+
+import           Data.Bool (Bool, (&&))
+import           Data.Eq (Eq(..))
+import           Data.Functor (Functor(..), (<$>))
+import           Data.Function (($), (.))
+
+import           Disorder.Jack.Combinators
+import           Disorder.Jack.Core
+import           Disorder.Jack.Property
+import           Disorder.Jack.Tree
+
+import           System.IO (IO)
+
+import           Text.Show (Show)
+import           Text.Show.Pretty (ppShow)
+
+import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Gen as QC
+
+
+data Info a b =
+  Info {
+      infoA :: Tree a
+    , infoB :: Tree b
+    , infoTreeApply :: Tree (a, b)
+    , infoTreeMonad :: Tree (a, b)
+    , infoJackApply :: Tree (a, b)
+    , infoJackMonad :: Tree (a, b)
+    } deriving (Show)
+
+genTrees :: Jack a -> Jack b -> QC.Gen (Info a b)
+genTrees ja jb =
+  QC.MkGen $ \r n ->
+    let
+      run g =
+        QC.unGen g r n
+
+      (a, b) =
+        run $ do
+          a0 <- runJack ja
+          b0 <- runJack jb
+          pure (a0, b0)
+    in
+      Info {
+          infoA = a
+        , infoB = b
+        , infoTreeApply = (,) <$> a <*> b
+        , infoTreeMonad = (,) `fmap` a `ap` b
+        , infoJackApply = run . runJack $ (,) <$> ja <*> jb
+        , infoJackMonad = run . runJack $ (,) `fmap` ja `ap` jb
+        }
+
+prop_ap_all_the_things :: Property
+prop_ap_all_the_things =
+  let
+    aa = chooseInt (1, 5)
+    bb = chooseChar ('a', 'e')
+  in
+    QC.forAll (genTrees aa bb) $ \(Info a b ta tm ja jm) ->
+      QC.counterexample "=== A ===" .
+      QC.counterexample (ppShow a) .
+      QC.counterexample "=== B ===" .
+      QC.counterexample (ppShow b) $
+      QC.counterexample "=== Tree Applicative ===" .
+      QC.counterexample (ppShow ta) $
+      QC.counterexample "=== Tree Monad ===" .
+      QC.counterexample (ppShow tm) $
+      QC.counterexample "=== Jack Applicative ===" .
+      QC.counterexample (ppShow ja) $
+      QC.counterexample "=== Jack Monad ===" .
+      QC.counterexample (ppShow jm) $
+        ta == tm &&
+        tm == ja &&
+        ja == jm
+
+return []
+tests :: IO Bool
+tests =
+  $forAllProperties . quickCheckWithResult $ stdArgs { maxSuccess = 1000 }

--- a/disorder-jack/test/test.hs
+++ b/disorder-jack/test/test.hs
@@ -1,6 +1,7 @@
 import           Disorder.Core.Main
 
 import qualified Test.Disorder.Jack.Combinators
+import qualified Test.Disorder.Jack.Core
 import qualified Test.Disorder.Jack.Minimal
 import qualified Test.Disorder.Jack.Property.Diff
 import qualified Test.Disorder.Jack.Shrink
@@ -10,6 +11,7 @@ main :: IO ()
 main =
   disorderMain [
       Test.Disorder.Jack.Combinators.tests
+    , Test.Disorder.Jack.Core.tests
     , Test.Disorder.Jack.Minimal.tests
     , Test.Disorder.Jack.Property.Diff.tests
     , Test.Disorder.Jack.Shrink.tests


### PR DESCRIPTION
After much pondering I think I've finally cracked the "right" bind implementation for `Gen (Tree a)`. We're careful to only split the seed once during the bind, and then we use the same seed for every gen in the `Tree (Gen (Tree b))`, this means that at last `ap` is equivalent to `<*>`, very exciting :)

To be concrete, these two generators now produce identical results:
```hs
foo :: Jack (Int, Int)
foo = do
  x <- choose (1, 10)
  y <- choose (1, 10)
  pure (x, y)

bar :: Jack (Int, Int)
bar =
  pure (,)
    <*> choose (1, 10)
    <*> choose (1, 10)
```

Previously the first generator would have a problem that if `x` was shrunk then we would generate an entirely new value for `y`, this no longer occurs as the seed for `y` remains the same no matter the shrinking which is applied to `x`.

One outstanding issue, which is annoying but probably won't cause an issue, is that this generator is not quite the same as the two above:
```hs
quux :: Jack (Int, Int)
quux =
  (,) <$> choose (1, 10) <*> choose (1, 10)
```
It will behave the same as far as being a distribution of values, but it is not the same function from `Seed -> (Int, Int)` because it only splits the seed once, where as `foo` and `bar` both split the seed twice. This is fundamental to how QuickCheck's `Gen` works, by splitting the seed whenever it encounters `>>=` or `<*>`.

! @charleso 