### PR TITLE
disorder-core: Add withJust/withRight combinators

### DIFF
--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -44,6 +44,7 @@ library
                        Disorder.Core.Tripping
                        Disorder.Core.UniquePair
                        Disorder.Core.QuickCheck
+                       Disorder.Core.Combinators
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/disorder-core/src/Disorder/Core.hs
+++ b/disorder-core/src/Disorder/Core.hs
@@ -8,3 +8,4 @@ import           Disorder.Core.Property as X
 import           Disorder.Core.Run as X
 import           Disorder.Core.Tripping as X
 import           Disorder.Core.UniquePair as X
+import           Disorder.Core.Combinators as X

--- a/disorder-core/src/Disorder/Core/Combinators.hs
+++ b/disorder-core/src/Disorder/Core/Combinators.hs
@@ -1,0 +1,25 @@
+module Disorder.Core.Combinators
+  ( testJust
+  , testRight
+  ) where
+
+
+import           Test.QuickCheck (Property, counterexample)
+
+
+-- | testRight label eitherValue nextProp :
+-- On a `Right`, pass the value to the next property.
+-- On a `Left` fail with a label and the left value.
+-- The label is useful for the case of nested `testRight`.
+testRight :: Show a => String -> Either a b -> (b -> Property) -> Property
+testRight _ (Right b) nextProp = nextProp b
+testRight label (Left a) _ = counterexample (label ++ ": " ++ show a) False
+
+
+-- | testJust label maybeValue nextProp
+-- On a `Just`, pass the value to the next property.
+-- On a `Nothing`, fail and print the label.
+-- The label is useful for the case of nested `testJust`/`testRight``.
+testJust :: String -> Maybe b -> (b -> Property) -> Property
+testJust _ (Just  b) nextProp = nextProp b
+testJust label _ _ = counterexample (label ++ ": Nothing ") False

--- a/disorder-core/test/Test/Disorder/Core/Combinators.hs
+++ b/disorder-core/test/Test/Disorder/Core/Combinators.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Test.Disorder.Core.Combinators where
+
+import           Disorder.Core.Combinators
+import           Disorder.Core.Run
+
+import           Test.QuickCheck (Property, (===), expectFailure)
+
+
+prop_testJust_Just :: (Show a, Eq a) => a -> Property
+prop_testJust_Just a =
+  testJust "just" (Just a) $ \ x -> x === a
+
+
+prop_testJust_both :: (Show a, Eq a) => Maybe a -> Property
+prop_testJust_both ma =
+  case ma of
+   Just _ -> testJust "just" ma $ \ a -> a === a
+   Nothing -> expectFailure . testJust "nothing" ma $ \ a -> a === a
+
+
+prop_testRight_Right :: (Show a, Eq a) => Either a a -> Property
+prop_testRight_Right eaa =
+  let ra = case eaa of
+            Left a -> Right a
+            Right _ -> eaa
+  in testRight "right" ra $ \ x -> x === x
+
+
+prop_testRight_both :: (Show a, Eq a, Show e) => Either e a -> Property
+prop_testRight_both ea =
+  case ea of
+   Right _ -> testRight "right" ea $ \ a -> a === a
+   Left _ -> expectFailure . testRight "left" ea $ \ a -> a === a
+
+
+return []
+tests :: IO Bool
+tests = $disorderCheckEnvAll TestRunMore

--- a/disorder-core/test/test.hs
+++ b/disorder-core/test/test.hs
@@ -5,6 +5,7 @@ import qualified Test.Disorder.Core.Tripping
 import qualified Test.Disorder.Core.UniquePair
 import qualified Test.Disorder.Core.OrdPair
 import qualified Test.Disorder.Core.IO
+import qualified Test.Disorder.Core.Combinators
 
 main :: IO ()
 main = disorderMain [
@@ -14,4 +15,5 @@ main = disorderMain [
   , Test.Disorder.Core.UniquePair.tests
   , Test.Disorder.Core.OrdPair.tests
   , Test.Disorder.Core.IO.tests
+  , Test.Disorder.Core.Combinators.tests
   ]


### PR DESCRIPTION
Keep needing `withRight` and decided to add `withJust` for completeness.
The label is useful when nesting operations like:

  withRight "parse" (parse string) -> $ \ whatever ->
  withRight "convert" (convert whatever) $ \ x -> validate x


! @jystic @charleso @tmcgilchrist 