### PR TITLE
Add leap second to UTCTime gen

### DIFF
--- a/disorder-aeson/src/Disorder/Aeson/Time.hs
+++ b/disorder-aeson/src/Disorder/Aeson/Time.hs
@@ -11,6 +11,11 @@ import           Test.QuickCheck
 import           Prelude
 
 genTime :: Gen UTCTime
-genTime = UTCTime
-  <$> fmap ModifiedJulianDay arbitrary
-  <*> fmap (picosecondsToDiffTime . (*) 1000000000) (choose (0, 60 * 60 * 24 * 1000))
+genTime = 
+  let
+    -- Add one for leap seconds.
+    maxDayMilliseconds = 60 * 60 * 24 * 1000 + 1000
+  in
+  UTCTime
+    <$> fmap ModifiedJulianDay arbitrary
+    <*> fmap (picosecondsToDiffTime . (*) 1000000000) (choose (0, maxDayMilliseconds))


### PR DESCRIPTION
UTCTime is clock time, not absolute time, so a gen should account for the
possibility of leap seconds.