### PR TITLE
Add extra indent when printing values of record fields

### DIFF
--- a/disorder-jack/src/Disorder/Jack/Property/Diff.hs
+++ b/disorder-jack/src/Disorder/Jack/Property/Diff.hs
@@ -45,7 +45,7 @@ renderDiffs val1 val2 = prints $ go 0 val1 val2
      , fmap (\(u,_) -> u) us == fmap (\(v,_) -> v) vs
      -> same i n
      -- Print field name too
-     <> goes (\i' (ix,u) (_,v) -> same i' (ix <> " =") <> go i' u v) "{" "," "}" i (List.zip us vs)
+     <> goes (\i' (ix,u) (_,v) -> same i' (ix <> " =") <> go (i' + 1) u v) "{" "," "}" i (List.zip us vs)
 
     -- Tuples and lists of same length
     (Pretty.Tuple us, Pretty.Tuple vs)

--- a/disorder-jack/test/Test/Disorder/Jack/Property/Diff.hs
+++ b/disorder-jack/test/Test/Disorder/Jack/Property/Diff.hs
@@ -92,15 +92,15 @@ prop_eg4 =
     (RecordWithFields 0 Nothing  [RecordWithFields 2 (Just 1) []])
     [ " RecordWithFields"
     , " { field1 ="
-    , "   0"
+    , "     0"
     , " , field2 ="
-    , "-  Just 1"
-    , "+  Nothing"
+    , "-    Just 1"
+    , "+    Nothing"
     , " , field3 ="
-    , "   ["
-    , "-    RecordWithFields { field1 = 2 , field2 = Nothing , field3 = [] }"
-    , "+    RecordWithFields { field1 = 2 , field2 = Just 1 , field3 = [] }"
-    , "   ]"
+    , "     ["
+    , "-      RecordWithFields { field1 = 2 , field2 = Nothing , field3 = [] }"
+    , "+      RecordWithFields { field1 = 2 , field2 = Just 1 , field3 = [] }"
+    , "     ]"
     , " }"
     ]
 


### PR DESCRIPTION
This adds one level of indent when rendering a record field's value.

Before:
```diff
=== Not equal ===
 [ Fact
   { factEntityHash =
     EntityHash 2200818614
   , factEntityId =
     EntityId "timmy"
   , factAttributeId =
-    AttributeId 0
+    AttributeId 1
   , factTime =
     Time 0
   , factFactsetId =
     FactsetId 0
   , factValue =
     Just' (BoolValue False)
   }
 ]
```

After:
```diff
=== Not equal ===
 [ Fact
   { factEntityHash =
       EntityHash 2200818614
   , factEntityId =
       EntityId "timmy"
   , factAttributeId =
-      AttributeId 0
+      AttributeId 1
   , factTime =
       Time 0
   , factFactsetId =
       FactsetId 0
   , factValue =
       Just' (BoolValue False)
   }
 ]
```

! @amosr 