### PR TITLE
Deprecrate quickcheck-text re-exports

### DIFF
--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -13,15 +13,17 @@ description:           disorder-core.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      >= 2.7        && < 2.9
+                     , bytestring                      == 0.10.*
                      , directory                       == 1.2.*
                      , ieee754                         == 0.7.*
-                     , quickcheck-text                 >= 0.1        && < 0.2
                      , process                         >= 1.2        && < 1.5
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.3        && < 1
                      , template-haskell                >= 2.4
+                     , quickcheck-text                 >= 0.1        && < 0.2
+                     , QuickCheck                      >= 2.7        && < 2.9
+
 
   ghc-options:         -Wall
   if impl(ghc >= 8.0)
@@ -61,11 +63,13 @@ test-suite test
   build-depends:
                        base                            >= 3          && < 5
                      , ambiata-disorder-core
-                     , QuickCheck                      >= 2.8.2      && < 2.9
-                     , text
-                     , quickcheck-instances            == 0.3.*
                      , ieee754                         == 0.7.*
+                     , text
                      , transformers                    >= 0.3        && < 1
+                     , quickcheck-instances            == 0.3.*
+                     , quickcheck-text                 >= 0.1        && < 0.2
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+
 
 test-suite test-cli
   type:                exitcode-stdio-1.0

--- a/disorder-core/src/Disorder/Core/Gen.hs
+++ b/disorder-core/src/Disorder/Core/Gen.hs
@@ -37,16 +37,61 @@ module Disorder.Core.Gen (
 
 import           Control.Applicative
 
+import           Data.ByteString (ByteString)
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as N
 import           Data.Maybe (isJust)
 import           Data.Monoid ((<>))
+import           Data.Text (Text)
 
 import           Test.QuickCheck.Gen
 import           Test.QuickCheck.Random
-import           Test.QuickCheck.Utf8
+import qualified Test.QuickCheck.Utf8 as Utf8
 
 import           Prelude
+
+{-# DEPRECATED genValidUtf8 "Use Test.QuickCheck.Utf8.genValidUtf8 instead" #-}
+genValidUtf8 :: Gen Text
+genValidUtf8 =
+  Utf8.genValidUtf8
+
+{-# DEPRECATED genValidUtf81 "Use Test.QuickCheck.Utf8.genValidUtf81 instead" #-}
+genValidUtf81 :: Gen Text
+genValidUtf81 =
+  Utf8.genValidUtf81
+
+#if MIN_VERSION_quickcheck_text(0, 1, 1)
+{-# DEPRECATED shrinkValidUtf8 "Use Test.QuickCheck.Utf8.shrinkValidUtf8 instead" #-}
+shrinkValidUtf8 :: Text -> [Text]
+shrinkValidUtf8 =
+  Utf8.shrinkValidUtf8
+
+{-# DEPRECATED shrinkValidUtf81 "Use Test.QuickCheck.Utf8.shrinkValidUtf81 instead" #-}
+shrinkValidUtf81 :: Text -> [Text]
+shrinkValidUtf81 =
+  Utf8.shrinkValidUtf81
+
+{-# DEPRECATED shrinkUtf8BS "Use Test.QuickCheck.Utf8.shrinkUtf8BS instead" #-}
+shrinkUtf8BS :: ByteString -> [ByteString]
+shrinkUtf8BS =
+  Utf8.shrinkUtf8BS
+
+{-# DEPRECATED shrinkUtf8BS1 "Use Test.QuickCheck.Utf8.shrinkUtf8BS1 instead" #-}
+shrinkUtf8BS1 :: ByteString -> [ByteString]
+shrinkUtf8BS1 =
+  Utf8.shrinkUtf8BS1
+
+{-# DEPRECATED utf8BS "Use Test.QuickCheck.Utf8.utf8BS instead" #-}
+utf8BS :: Gen ByteString
+utf8BS =
+  Utf8.utf8BS
+
+{-# DEPRECATED utf8BS1 "Use Test.QuickCheck.Utf8.utf8BS1 instead" #-}
+utf8BS1 :: Gen ByteString
+utf8BS1 =
+  Utf8.utf8BS1
+#endif
+
 
 -- | Return a vector whose size is within the provided bounds
 vectorOfSize :: Int -> Int -> Gen a -> Gen [a]

--- a/disorder-core/test/Test/Disorder/Core/Gen.hs
+++ b/disorder-core/test/Test/Disorder/Core/Gen.hs
@@ -11,8 +11,7 @@ import           Disorder.Core.OrdPair
 import           Disorder.Core.Run
 
 import           Test.QuickCheck
-
-
+import qualified Test.QuickCheck.Utf8 as Utf8
 
 prop_vectorOfSize :: OrdPair (Positive Int) -> Positive Int -> Property
 prop_vectorOfSize (OrdPair (Positive x) (Positive y)) (Positive s) = testIO $ do
@@ -43,18 +42,18 @@ prop_genFromMaybe =
 prop_vectorOfUnique :: Property
 prop_vectorOfUnique =
   forAll (choose (0, 100)) $ \n ->
-    forAll (vectorOfUnique n genValidUtf8) $ \xs ->
+    forAll (vectorOfUnique n Utf8.genValidUtf8) $ \xs ->
       (xs, length xs) === (nub xs, n)
 
 prop_vectorOfUnique' :: Property
 prop_vectorOfUnique' =
   expectFailure $
-    forAll (vectorOfUnique' 0 10 genValidUtf8) $ \xs ->
+    forAll (vectorOfUnique' 0 10 Utf8.genValidUtf8) $ \xs ->
       xs === nub xs
 
 prop_listOf1Unique :: Property
 prop_listOf1Unique =
-  forAll (listOf1Unique genValidUtf8) $ \xs ->
+  forAll (listOf1Unique Utf8.genValidUtf8) $ \xs ->
     conjoin [
         xs === nub xs
       , (length xs >= 1) === True
@@ -62,7 +61,7 @@ prop_listOf1Unique =
 
 prop_listOf1UniquePair :: Property
 prop_listOf1UniquePair =
-  forAll (listOf1UniquePair genValidUtf8) $ \(xs, ys) ->
+  forAll (listOf1UniquePair Utf8.genValidUtf8) $ \(xs, ys) ->
     conjoin [
         xs <> ys === nub (xs <> ys)
       , (length (xs <> ys) >= 1) === True


### PR DESCRIPTION
! @jystic @erikd-ambiata @tmcgilchrist @thumphries 

Born from the discussion around https://github.com/ambiata/disorder.hs/pull/109 that we should probably have never been re-exporting these functions. Easier to continue that over a PR.

Also, is there a way to just add a deprecation to an item in the exports list? :(
/jury approved @erikd-ambiata