### PR TITLE
Deprecate corpus newtypes

### DIFF
--- a/disorder-corpus/src/Disorder/Corpus.hs
+++ b/disorder-corpus/src/Disorder/Corpus.hs
@@ -3,48 +3,40 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Disorder.Corpus (
-    genCorpus
-  , shrinkCorpus
+    cooking
+  , muppets
+  , southpark
+  , simpsons
+  , viruses
+  , colours
+  , weather
+  , waters
+  , boats
+  , glass
 
+  -- * Deprecated
+  , genCorpus
+  , shrinkCorpus
   , Cooking(..)
   , unCooking
-  , cooking
-
   , Muppet(..)
   , unMuppet
-  , muppets
-
   , Southpark(..)
   , unSouthpark
-  , southpark
-
   , Simpson(..)
   , unSimpson
-  , simpsons
-
   , Virus(..)
   , unVirus
-  , viruses
-
   , Colour(..)
   , unColour
-  , colours
-
   , Weather(..)
   , unWeather
-  , weather
-
   , Water(..)
   , unWater
-  , waters
-
   , Boat(..)
   , unBoat
-  , boats
-
   , Glass(..)
   , unGlass
-  , glass
   ) where
 
 import           Data.Data (Data)
@@ -64,48 +56,6 @@ import           Text.Show (Show)
 import           Text.Read (Read)
 
 
--- | Generate something in the corpus or something completely bonkers.
-genCorpus :: [a] -> (a -> b) -> Gen a -> Gen b
-genCorpus corpus f gen =
-  oneof [
-      fmap f (elements corpus)
-    , fmap f gen
-    ]
-
--- | Shrinks 'b', preferring to return things from the corpus. If 'b' is
---   already from the corpus then shrinks to nothing.
-shrinkCorpus :: Eq a => [a] -> (a -> b) -> (b -> a) -> (a -> [a]) -> b -> [b]
-shrinkCorpus corpus f g shrinkA b =
-  let
-    a = g b
-  in
-    if List.elem a corpus then
-      []
-    else
-      -- Items at the start of the shrink list are tried first by QuickCheck,
-      -- so put the corpus items first and hopefully we'll get a nicer
-      -- counterexample.
-      fmap f (corpus <> shrinkA a)
-
---
--- The newtypes below have the unXXX function defined separately so that
--- the derived Show instance produces output which is easier to read.
---
-
-newtype Cooking a =
-  Cooking a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unCooking :: Cooking a -> a
-unCooking (Cooking x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Cooking a) where
-  arbitrary =
-    genCorpus cooking Cooking arbitrary
-  shrink =
-    shrinkCorpus cooking Cooking unCooking shrink
-
 cooking :: IsString a => [a]
 cooking = [
     "salted"
@@ -114,21 +64,6 @@ cooking = [
   , "filleted"
   , "sauteed"
   ]
-
-
-newtype Muppet a =
-  Muppet a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unMuppet :: Muppet a -> a
-unMuppet (Muppet x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Muppet a) where
-  arbitrary =
-    genCorpus muppets Muppet arbitrary
-  shrink =
-    shrinkCorpus muppets Muppet unMuppet shrink
 
 muppets :: IsString a => [a]
 muppets = [
@@ -142,21 +77,6 @@ muppets = [
   , "animal"
   ]
 
-
-newtype Southpark a =
-  Southpark a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unSouthpark :: Southpark a -> a
-unSouthpark (Southpark x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Southpark a) where
-  arbitrary =
-    genCorpus southpark Southpark arbitrary
-  shrink =
-    shrinkCorpus southpark Southpark unSouthpark shrink
-
 southpark :: IsString a => [a]
 southpark = [
     "kyle"
@@ -167,21 +87,6 @@ southpark = [
   , "chef"
   , "garrison"
   ]
-
-
-newtype Simpson a =
-  Simpson a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unSimpson :: Simpson a -> a
-unSimpson (Simpson x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Simpson a) where
-  arbitrary =
-    genCorpus simpsons Simpson arbitrary
-  shrink =
-    shrinkCorpus simpsons Simpson unSimpson shrink
 
 simpsons :: IsString a => [a]
 simpsons = [
@@ -194,21 +99,6 @@ simpsons = [
   , "moe"
   , "barney"
   ]
-
-
-newtype Virus a =
-  Virus a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unVirus :: Virus a -> a
-unVirus (Virus x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Virus a) where
-  arbitrary =
-    genCorpus viruses Virus arbitrary
-  shrink =
-    shrinkCorpus viruses Virus unVirus shrink
 
 viruses :: IsString a => [a]
 viruses = [
@@ -225,21 +115,6 @@ viruses = [
   , "monkeypox"
   ]
 
-
-newtype Colour a =
-  Colour a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unColour :: Colour a -> a
-unColour (Colour x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Colour a) where
-  arbitrary =
-    genCorpus colours Colour arbitrary
-  shrink =
-    shrinkCorpus colours Colour unColour shrink
-
 colours :: IsString a => [a]
 colours = [
     "red"
@@ -253,21 +128,6 @@ colours = [
   , "pink"
   ]
 
-
-newtype Weather a =
-  Weather a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unWeather :: Weather a -> a
-unWeather (Weather x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Weather a) where
-  arbitrary =
-    genCorpus weather Weather arbitrary
-  shrink =
-    shrinkCorpus weather Weather unWeather shrink
-
 weather :: IsString a => [a]
 weather = [
     "dry"
@@ -279,21 +139,6 @@ weather = [
   , "windy"
   , "freezing"
   ]
-
-
-newtype Water a =
-  Water a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unWater :: Water a -> a
-unWater (Water x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Water a) where
-  arbitrary =
-    genCorpus waters Water arbitrary
-  shrink =
-    shrinkCorpus waters Water unWater shrink
 
 waters :: IsString a => [a]
 waters = [
@@ -323,21 +168,6 @@ waters = [
   , "wetland"
   ]
 
-
-newtype Boat a =
-  Boat a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unBoat :: Boat a -> a
-unBoat (Boat x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Boat a) where
-  arbitrary =
-    genCorpus boats Boat arbitrary
-  shrink =
-    shrinkCorpus boats Boat unBoat shrink
-
 boats :: IsString a => [a]
 boats = [
     "barge"
@@ -361,20 +191,6 @@ boats = [
   , "tugboat"
   , "yacht"
   ]
-
-newtype Glass a =
-  Glass a
-  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
-
-unGlass :: Glass a -> a
-unGlass (Glass x) =
-  x
-
-instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Glass a) where
-  arbitrary =
-    genCorpus glass Glass arbitrary
-  shrink =
-    shrinkCorpus glass Glass unGlass shrink
 
 -- | How to say "I can eat glass, and it doesn't hurt me." in a few different
 --   languages.
@@ -538,3 +354,175 @@ glass = [
   , "mi kakne le nu citka le blaci .iku'i le se go'i na xrani mi" -- Lojban
   , "Ljœr ye caudran créneþ ý jor cẃran." -- Nórdicg
   ]
+
+------------------------------------------------------------------------
+-- Deprecated
+
+-- | Generate something in the corpus or something completely bonkers.
+genCorpus :: [a] -> (a -> b) -> Gen a -> Gen b
+genCorpus corpus f gen =
+  oneof [
+      fmap f (elements corpus)
+    , fmap f gen
+    ]
+
+-- | Shrinks 'b', preferring to return things from the corpus. If 'b' is
+--   already from the corpus then shrinks to nothing.
+shrinkCorpus :: Eq a => [a] -> (a -> b) -> (b -> a) -> (a -> [a]) -> b -> [b]
+shrinkCorpus corpus f g shrinkA b =
+  let
+    a = g b
+  in
+    if List.elem a corpus then
+      []
+    else
+      -- Items at the start of the shrink list are tried first by QuickCheck,
+      -- so put the corpus items first and hopefully we'll get a nicer
+      -- counterexample.
+      fmap f (corpus <> shrinkA a)
+
+--
+-- The newtypes below have the unXXX function defined separately so that
+-- the derived Show instance produces output which is easier to read.
+--
+
+newtype Cooking a =
+  Cooking a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unCooking :: Cooking a -> a
+unCooking (Cooking x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Cooking a) where
+  arbitrary =
+    genCorpus cooking Cooking arbitrary
+  shrink =
+    shrinkCorpus cooking Cooking unCooking shrink
+
+newtype Muppet a =
+  Muppet a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unMuppet :: Muppet a -> a
+unMuppet (Muppet x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Muppet a) where
+  arbitrary =
+    genCorpus muppets Muppet arbitrary
+  shrink =
+    shrinkCorpus muppets Muppet unMuppet shrink
+
+newtype Southpark a =
+  Southpark a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSouthpark :: Southpark a -> a
+unSouthpark (Southpark x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Southpark a) where
+  arbitrary =
+    genCorpus southpark Southpark arbitrary
+  shrink =
+    shrinkCorpus southpark Southpark unSouthpark shrink
+
+newtype Simpson a =
+  Simpson a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSimpson :: Simpson a -> a
+unSimpson (Simpson x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Simpson a) where
+  arbitrary =
+    genCorpus simpsons Simpson arbitrary
+  shrink =
+    shrinkCorpus simpsons Simpson unSimpson shrink
+
+
+newtype Virus a =
+  Virus a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unVirus :: Virus a -> a
+unVirus (Virus x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Virus a) where
+  arbitrary =
+    genCorpus viruses Virus arbitrary
+  shrink =
+    shrinkCorpus viruses Virus unVirus shrink
+
+newtype Colour a =
+  Colour a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unColour :: Colour a -> a
+unColour (Colour x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Colour a) where
+  arbitrary =
+    genCorpus colours Colour arbitrary
+  shrink =
+    shrinkCorpus colours Colour unColour shrink
+
+newtype Weather a =
+  Weather a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWeather :: Weather a -> a
+unWeather (Weather x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Weather a) where
+  arbitrary =
+    genCorpus weather Weather arbitrary
+  shrink =
+    shrinkCorpus weather Weather unWeather shrink
+
+newtype Water a =
+  Water a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWater :: Water a -> a
+unWater (Water x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Water a) where
+  arbitrary =
+    genCorpus waters Water arbitrary
+  shrink =
+    shrinkCorpus waters Water unWater shrink
+
+newtype Boat a =
+  Boat a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unBoat :: Boat a -> a
+unBoat (Boat x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Boat a) where
+  arbitrary =
+    genCorpus boats Boat arbitrary
+  shrink =
+    shrinkCorpus boats Boat unBoat shrink
+
+newtype Glass a =
+  Glass a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unGlass :: Glass a -> a
+unGlass (Glass x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Glass a) where
+  arbitrary =
+    genCorpus glass Glass arbitrary
+  shrink =
+    shrinkCorpus glass Glass unGlass shrink


### PR DESCRIPTION
The newtypes were hard to use and never really worked out, they are superseded by generators with integrated shrinking in `disorder-jack` and `hedgehog`. As far as I know they are only still in use in `snooker`.

I feel like having them intermixed with the corpus lists may have scared people off adding new corpuses so I wanted to make it clear that you don't need to worry about them when adding a new corpus.

! @nhibberd