### PR TITLE
Bump Quickcheck version to be up to 2.11

### DIFF
--- a/boris.toml
+++ b/boris.toml
@@ -1,54 +1,6 @@
 [boris]
   version = 1
 
-[build.dist-7-8-core]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-core"]]
-
-[build.dist-7-8-corpus]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-corpus"]]
-
-[build.dist-7-8-jack]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-jack"]]
-
-[build.dist-7-8-cli]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-cli"]]
-
-[build.dist-7-8-aeson]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-aeson"]]
-
-[build.dist-7-8-eithert]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-eithert"]]
-
-[build.dist-7-8-fsm]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-fsm"]]
-
-[build.dist-7-8-lens]
-  command = [["master", "build", "dist-7-8", "-C", "disorder-lens"]]
-
-[build.dist-7-10-core]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-core"]]
-
-[build.dist-7-10-corpus]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-corpus"]]
-
-[build.dist-7-10-jack]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-jack"]]
-
-[build.dist-7-10-cli]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-cli"]]
-
-[build.dist-7-10-aeson]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-aeson"]]
-
-[build.dist-7-10-eithert]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-eithert"]]
-
-[build.dist-7-10-fsm]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-fsm"]]
-
-[build.dist-7-10-lens]
-  command = [["master", "build", "dist-7-10", "-C", "disorder-lens"]]
-
 [build.dist-8-0-core]
   command = [["master", "build", "dist-8-0", "-C", "disorder-core"]]
 
@@ -72,30 +24,6 @@
 
 [build.dist-8-0-lens]
   command = [["master", "build", "dist-8-0", "-C", "disorder-lens"]]
-
-[build.branches-7-8-core]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-core"]]
-
-[build.branches-7-8-corpus]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-corpus"]]
-
-[build.branches-7-8-jack]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-jack"]]
-
-[build.branches-7-8-cli]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-cli"]]
-
-[build.branches-7-8-aeson]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-aeson"]]
-
-[build.branches-7-8-eithert]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-eithert"]]
-
-[build.branches-7-8-fsm]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-fsm"]]
-
-[build.branches-7-8-lens]
-  command = [["master", "build", "branches-7-8", "-C", "disorder-lens"]]
 
 [build.branches-7-10-core]
   command = [["master", "build", "branches-7-10", "-C", "disorder-core"]]

--- a/disorder-aeson/ambiata-disorder-aeson.cabal
+++ b/disorder-aeson/ambiata-disorder-aeson.cabal
@@ -1,12 +1,12 @@
 name:                  ambiata-disorder-aeson
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-aeson
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-aeson.
 
@@ -15,8 +15,11 @@ library
                        base                            >= 3          && < 6
                      , aeson                           >= 0.8        && < 1.2
                      , ambiata-disorder-core
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
                      , time
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall
@@ -40,8 +43,11 @@ test-suite test
                        test
 
   build-depends:
-                       base                            >= 3          && < 6
+                       base
                      , ambiata-disorder-aeson
                      , aeson
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck
                      , time
+
+  default-language:
+                      Haskell2010

--- a/disorder-cli/ambiata-disorder-cli.cabal
+++ b/disorder-cli/ambiata-disorder-cli.cabal
@@ -1,12 +1,12 @@
 name:                  ambiata-disorder-cli
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-cli
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.24
 build-type:            Simple
 description:           disorder-cli.
 
@@ -22,6 +22,9 @@ library
                      -- https://github.com/Gabriel439/Haskell-Managed-Library/issues/6
                      , transformers                    >= 0.4        && < 0.6
                      , turtle                          == 1.2.*
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall
@@ -40,9 +43,12 @@ test-suite test-io
   hs-source-dirs:      test
   build-depends:       base                            >= 3          && < 6
                      , QuickCheck                      >= 2.7        && < 2.10
+                     , ambiata-disorder-core
                      , ambiata-disorder-cli
-                     , directory                       == 1.2.*
-                     , ieee754                         == 0.7.*
-                     , process                         >= 1.2        && < 1.5
-                     , text                            >= 1.1        && < 1.3
-                     , turtle                          == 1.2.*
+                     , directory
+                     , ieee754
+                     , process
+                     , text
+                     , turtle
+  default-language:
+                      Haskell2010

--- a/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
+++ b/disorder-cli/test/Test/IO/Disorder/Cli/Shell.hs
@@ -9,6 +9,7 @@ import           Data.Monoid
 import qualified Data.Text               as T
 
 import           Disorder.Cli.Shell
+import           Disorder.Core.IO
 
 import           System.Exit
 
@@ -23,17 +24,17 @@ boring :: Gen Text
 boring = fmap T.pack . listOf1 $ elements (['a'..'z'] <> ['A'..'Z'] <> ['0'..'9'])
 
 prop_testShell :: Property
-prop_testShell = forAll (listOf1 boring) $ \ms -> (monadicIO . (=<<) stop . run) $ do
+prop_testShell = forAll (listOf1 boring) $ \ms -> (monadicIO . (=<<) stopIO . run) $ do
   (st, out) <- testShell ["tac"] $ select ms
   pure $ (st, out) === (ExitSuccess, flip T.snoc '\n' $ T.intercalate "\n" (reverse ms))
 
 prop_testShell_succ :: Property
-prop_testShell_succ = forAll boring $ \m -> (monadicIO . (=<<) stop . run) $ do
+prop_testShell_succ = forAll boring $ \m -> (monadicIO . (=<<) stopIO . run) $ do
   (st, out) <- testShell' ["echo", "-n", m]
   pure $ (st, out) === (ExitSuccess, m)
 
 prop_testShell_fail :: Property
-prop_testShell_fail = forAll boring $ \m -> (monadicIO . (=<<) stop . run) $ do
+prop_testShell_fail = forAll boring $ \m -> (monadicIO . (=<<) stopIO . run) $ do
   (st, out) <- testShell' ["echo", "-n", m, "&&", "false"]
   pure $ (st == ExitSuccess, out) === (False, m)
 

--- a/disorder-core/ambiata-disorder-core.cabal
+++ b/disorder-core/ambiata-disorder-core.cabal
@@ -1,19 +1,20 @@
 name:                  ambiata-disorder-core
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-core
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-core.
+tested-with:           GHC==8.0.2, GHC==7.10.2
 
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
                      , directory                       >= 1.2        && < 1.4
                      , ieee754                         >= 0.7        && < 0.9
                      , quickcheck-text                 >= 0.1        && < 0.2
@@ -22,6 +23,9 @@ library
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.3        && < 1
                      , template-haskell                >= 2.4
+
+  default-language:
+                      Haskell2010
 
   ghc-options:         -Wall
   if impl(ghc >= 8.0)
@@ -58,13 +62,16 @@ test-suite test
                        test
 
   build-depends:
-                       base                            >= 3          && < 5
+                       base
                      , ambiata-disorder-core
-                     , QuickCheck                      >= 2.8.2      && < 2.10
+                     , QuickCheck
                      , text
                      , quickcheck-instances            == 0.3.*
-                     , ieee754                         >= 0.7        && < 0.9
-                     , transformers                    >= 0.3        && < 1
+                     , ieee754
+                     , transformers
+
+  default-language:
+                      Haskell2010
 
 test-suite test-cli
   type:                exitcode-stdio-1.0
@@ -79,5 +86,8 @@ test-suite test-cli
                        test
 
   build-depends:
-                       base                            >= 3          && < 5
+                       base
                      , ambiata-disorder-core
+
+  default-language:
+                      Haskell2010

--- a/disorder-core/ambiata-disorder-core.lock-8.0.2
+++ b/disorder-core/ambiata-disorder-core.lock-8.0.2
@@ -1,0 +1,23 @@
+# mafia-lock-file-version: 0
+base-compat == 0.10.5
+case-insensitive == 1.2.0.11
+hashable == 1.2.7.0
+ieee754 == 0.8.0
+integer-logarithms == 1.0.2.2
+old-locale == 1.0.0.7
+old-time == 1.1.0.3
+primitive == 0.6.4.0
+QuickCheck == 2.11.3
+quickcheck-instances == 0.3.19
+quickcheck-text == 0.1.2.1
+random == 1.1
+scientific == 0.3.6.2
+semigroups == 0.18.5
+tagged == 0.8.6
+text == 1.2.3.1
+tf-random == 0.5
+transformers-compat == 0.6.2
+transformers-compat +five
+unordered-containers == 0.2.9.0
+uuid-types == 1.0.3
+vector == 0.12.0.2

--- a/disorder-core/src/Disorder/Core/IO.hs
+++ b/disorder-core/src/Disorder/Core/IO.hs
@@ -1,5 +1,6 @@
 module Disorder.Core.IO (
-    testIO
+    stopIO
+  , testIO
   , testPropertyIO
   , withCPUTime
   ) where
@@ -15,7 +16,7 @@ testIO :: Testable a => IO a -> Property
 testIO = testPropertyIO . run
 
 testPropertyIO :: Testable a => PropertyM IO a -> Property
-testPropertyIO = monadicIO . (=<<) stop
+testPropertyIO = monadicIO . (=<<) stopIO
 
 -- | Perform an action and return the CPU time it takes, in picoseconds
 -- (actual precision varies with implementation).
@@ -25,3 +26,7 @@ withCPUTime a = do
   r <- a
   t2 <- liftIO getCPUTime
   return (t2 - t1, r)
+
+-- | A IO typed version of Test.QuickCheck.Monadic.stop due to changes in QuickCheck 2.10
+stopIO :: (Testable a) => a -> PropertyM IO a
+stopIO p = MkPropertyM (\_k -> return (return (property p)))

--- a/disorder-core/test/Test/Disorder/Core/IO.hs
+++ b/disorder-core/test/Test/Disorder/Core/IO.hs
@@ -12,9 +12,10 @@ prop_falseFails :: Property
 prop_falseFails
   = expectFailure $ testPropertyIO $ return False
 
+-- needs stopID for QuickCheck >= 2.10, as it now takes a Testable so false is a fail
 prop_falseDoesNotFail :: Property
-prop_falseDoesNotFail
-  = monadicIO $ liftIO $ return False
+prop_falseDoesNotFail =
+  (monadicIO . (=<<) stopIO . run) $ liftIO $ return True
 
 return []
 tests :: IO Bool

--- a/disorder-corpus/ambiata-disorder-corpus.cabal
+++ b/disorder-corpus/ambiata-disorder-corpus.cabal
@@ -1,19 +1,22 @@
 name:                  ambiata-disorder-corpus
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-corpus
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-corpus.
 
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall
@@ -36,7 +39,10 @@ test-suite test
                        test
 
   build-depends:
-                       base                            >= 3          && < 5
+                       base
                      , ambiata-disorder-corpus
                      , text
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck
+
+  default-language:
+                      Haskell2010

--- a/disorder-eithert/ambiata-disorder-eithert.cabal
+++ b/disorder-eithert/ambiata-disorder-eithert.cabal
@@ -1,21 +1,24 @@
 name:                  ambiata-disorder-eithert
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-eithert
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-eithert.
 
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.4        && < 1
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall

--- a/disorder-fsm/ambiata-disorder-fsm.cabal
+++ b/disorder-fsm/ambiata-disorder-fsm.cabal
@@ -1,12 +1,12 @@
 name:                  ambiata-disorder-fsm
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              Final state machine testing
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           Final state machine testing.
 
@@ -16,9 +16,12 @@ library
                      , containers                      >= 0.5        && < 0.7
                      , exceptions                      == 0.8.*
                      , mtl                             >= 2.1        && < 2.3
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
                      , time
                      , transformers                    >= 0.3        && < 1
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall
@@ -54,3 +57,6 @@ test-suite test
                      , QuickCheck
                      , temporary                      >= 1.1        && < 1.3
                      , transformers
+
+  default-language:
+                      Haskell2010

--- a/disorder-fsm/test/Test/Disorder/FSM/Cont.hs
+++ b/disorder-fsm/test/Test/Disorder/FSM/Cont.hs
@@ -236,8 +236,7 @@ anyFile opened = L.any ((== opened) . isJust) . fmap fileHandle . M.elems . file
 anyClosedNonEmptyFile :: FileSystem -> Bool
 anyClosedNonEmptyFile = L.any (\(File mh ls) -> isNothing mh && ls /= []) . M.elems . fileSystemFiles
 
-
-monadicCont :: PropertyM (CatchableContT Property IO) a -> Property
+monadicCont :: Testable a => PropertyM (CatchableContT Property IO) a -> Property
 monadicCont = monadic $ ioProperty . evalCatchableContT
 
 evalContT :: (Monad m) => ContT r m r -> m r

--- a/disorder-jack/ambiata-disorder-jack.cabal
+++ b/disorder-jack/ambiata-disorder-jack.cabal
@@ -1,12 +1,12 @@
 name:                  ambiata-disorder-jack
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-jack
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-jack.
 
@@ -17,12 +17,17 @@ library
                      , containers                      >= 0.4        && < 0.6
                      , deepseq                         >= 1.2        && < 1.5
                      , pretty-show                     >= 1.6        && < 1.7
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     -- TODO something broken in 2.11 for jack
+                     -- prop_ap_all_the_things from test/Test/Disorder/Jack/Core.hs:59 fails
+                     , QuickCheck                      >= 2.7        && < 2.11
                      , quickcheck-text                 >= 0.1        && < 0.2
                      , random                          >= 1.1        && < 1.2
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            >= 1.1        && < 1.3
                      , transformers                    >= 0.3        && < 0.6
+
+  default-language:
+                      Haskell2010
 
   ghc-options:         -Wall
 
@@ -59,14 +64,17 @@ test-suite test
                        test
 
   build-depends:
-                       base                            >= 3          && < 5
+                       base
                      , ambiata-disorder-core
                      , ambiata-disorder-jack
-                     , comonad                         >= 4.2        && < 5.1
-                     , containers                      >= 0.4        && < 0.6
-                     , pretty-show                     >= 1.6        && < 1.7
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , comonad
+                     , containers
+                     , pretty-show
+                     , QuickCheck
                      , quickcheck-instances            == 0.3.*
-                     , semigroups                      >= 0.16       && < 0.19
-                     , text                            >= 1.1        && < 1.3
-                     , transformers                    >= 0.3        && < 0.6
+                     , semigroups
+                     , text
+                     , transformers
+
+  default-language:
+                      Haskell2010

--- a/disorder-lens/ambiata-disorder-lens.cabal
+++ b/disorder-lens/ambiata-disorder-lens.cabal
@@ -1,12 +1,12 @@
 name:                  ambiata-disorder-lens
-version:               0.0.1
+version:               0.0.2
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata
 synopsis:              disorder-lens
 category:              System
-cabal-version:         >= 1.8
+cabal-version:         >= 1.22
 build-type:            Simple
 description:           disorder-lens.
 
@@ -14,7 +14,10 @@ library
   build-depends:
                        base                            >= 3          && < 5
                      , lens                            >= 4.6        && < 4.16
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck                      >= 2.7        && < 2.12
+
+  default-language:
+                      Haskell2010
 
   ghc-options:
                        -Wall
@@ -41,7 +44,10 @@ test-suite test
                        test
 
   build-depends:
-                       base                            >= 3          && < 5
+                       base
                      , ambiata-disorder-lens
                      , lens
-                     , QuickCheck                      >= 2.7        && < 2.10
+                     , QuickCheck
+
+  default-language:
+                      Haskell2010

--- a/framework/mafia
+++ b/framework/mafia
@@ -1,123 +1,64 @@
-#!/bin/sh -eu
+#!/bin/bash -eu
 
 : ${MAFIA_HOME:=$HOME/.mafia}
-
-fetch_latest () {
-  if [ -z ${MAFIA_TEST_MODE+x} ]; then
-    TZ=$(date +"%T")
-    curl --silent "https://raw.githubusercontent.com/ambiata/mafia/master/script/mafia?$TZ"
-  else
-    cat ../script/mafia
-  fi
-}
+: ${MAFIA_VERSIONS:=$MAFIA_HOME/versions}
+: ${MAFIA_GIT_URL:="https://github.com/ambiata/mafia"}
+: ${MAFIA_GIT_BRANCH:="ambiata"}
 
 latest_version () {
-  git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+    git ls-remote ${MAFIA_GIT_URL} | grep "refs/heads/$MAFIA_GIT_BRANCH" | cut -f 1
 }
 
-local_version () {
-  awk '/^# Version: / { print $3; exit 0; }' $0
+build_version() {
+    MAFIA_VERSION="$1"
+    MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
+    MAFIA_FILE=mafia-$MAFIA_VERSION
+    MAFIA_PATH=$MAFIA_VERSIONS/$MAFIA_FILE
+    mkdir -p $MAFIA_VERSIONS
+    echo "Building $MAFIA_FILE in $MAFIA_TEMP"
+    git clone ${MAFIA_GIT_URL} $MAFIA_TEMP
+    git --git-dir="$MAFIA_TEMP/.git" --work-tree="$MAFIA_TEMP" reset --hard $MAFIA_VERSION || {
+        echo "mafia version ($MAFIA_VERSION) could not be found." >&2
+        exit 1
+    }
+    (cd "$MAFIA_TEMP" && ./bin/bootstrap) || {
+        got=$?
+        echo "mafia version ($MAFIA_VERSION) could not be built." >&2
+        exit "$got"
+    }
+    chmod +x "$MAFIA_TEMP/.cabal-sandbox/bin/mafia"
+    # Ensure executable is on same file-system so final mv is atomic.
+    mv -f "$MAFIA_TEMP/.cabal-sandbox/bin/mafia" "$MAFIA_PATH.$$"
+    mv "$MAFIA_PATH.$$" "$MAFIA_PATH" || {
+        rm -f "$MAFIA_PATH.$$"
+        echo "INFO: mafia version ($MAFIA_VERSION) already exists not overiding," >&2
+        echo "INFO: this is expected if parallel builds of the same version of" >&2
+        echo "INFO: mafia occur, we are playing by first in, wins." >&2
+        exit 0
+    }
 }
 
-run_upgrade () {
-  MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
-
-  clean_up () {
-    rm -f "$MAFIA_TEMP"
-  }
-
-  trap clean_up EXIT
-
-  MAFIA_CUR="$0"
-
-  if [ -L "$MAFIA_CUR" ]; then
-    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
-    exit 1
-  fi
-
-  echo "Checking for a new version of mafia ..."
-  fetch_latest > $MAFIA_TEMP
-
-  LATEST_VERSION=$(latest_version)
-  echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
-
-  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
-    mv $MAFIA_TEMP $MAFIA_CUR
-    chmod +x $MAFIA_CUR
-    echo "New version found and upgraded. You can now commit it to your git repo."
-  else
-    echo "You have latest mafia."
-  fi
+enable_version() {
+    if [ $# -eq 0 ]; then
+        MAFIA_VERSION="$(latest_version)"
+        echo "INFO: No explicit mafia version requested installing latest ($MAFIA_VERSION)." >&2
+    else
+        MAFIA_VERSION="$1"
+    fi
+    [ -x "${MAFIA_VERSIONS}/mafia-$MAFIA_VERSION" ] || build_version "$MAFIA_VERSION"
+    ln -sf "${MAFIA_VERSIONS}/mafia-$MAFIA_VERSION" "${MAFIA_VERSIONS}/mafia"
 }
 
 exec_mafia () {
-  MAFIA_VERSION=$(local_version)
-
-  if [ "x$MAFIA_VERSION" = "x" ]; then
-    # If we can't find the mafia version, then we need to upgrade the script.
-    run_upgrade
-  else
-    MAFIA_BIN=$MAFIA_HOME/bin
-    MAFIA_FILE=mafia-$MAFIA_VERSION
-    MAFIA_PATH=$MAFIA_BIN/$MAFIA_FILE
-
-    [ -f "$MAFIA_PATH" ] || {
-      # Create a temporary directory which will be deleted when the script
-      # terminates. Unfortunately `mktemp` doesn't behave the same on
-      # Linux and OS/X so we need to try two different approaches.
-      MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
-
-      # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
-      mkdir -p $MAFIA_BIN
-
-      clean_up () {
-        rm -rf "$MAFIA_TEMP"
-      }
-
-      trap clean_up EXIT
-
-      echo "Building $MAFIA_FILE in $MAFIA_TEMP"
-
-      ( cd "$MAFIA_TEMP"
-
-        git clone https://github.com/ambiata/mafia
-        cd mafia
-
-        git reset --hard $MAFIA_VERSION
-
-        bin/bootstrap ) || exit $?
-
-      MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
-
-      clean_up_temp () {
-        clean_up
-        rm -f "$MAFIA_PATH_TEMP"
-      }
-      trap clean_up_temp EXIT
-
-      cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
-      chmod 755 "$MAFIA_PATH_TEMP"
-      mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
-
-      clean_up_temp
-    }
-
-    exec $MAFIA_PATH "$@"
-  fi
+    [ -x "${MAFIA_VERSIONS}/mafia" ] || enable_version
+    "${MAFIA_VERSIONS}/mafia" "$@"
 }
 
 #
 # The actual start of the script.....
 #
 
-if [ $# -gt 0 ]; then
-  MODE="$1"
-else
-  MODE=""
-fi
-
-case "$MODE" in
-upgrade) shift; run_upgrade "$@" ;;
+case "${1:-}" in
+upgrade) shift; enable_version "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: 8bcf922a5993d8d566a6682db5a493e90300da9a

--- a/framework/master.toml
+++ b/framework/master.toml
@@ -1,36 +1,35 @@
 [master]
-  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20160603003512-3d86f6c/master-haskell-20160603003512-3d86f6c"
+  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20190103044641-3857bee/master-haskell-20190103044641-3857bee"
   version = 1
-  sha1 = "4fd979c87b2dfd7d8909ae052f3aeb66939b4bc2"
+  sha1 = "c8396097bdf46fa16aae6660f8d1f3ea7a4bce72"
 
-[build.dist]
-  GHC_VERSION = "7.10.2"
-  CABAL_VERSION = "1.22.4.0"
+[global]
+  CACHE = "true"
 
-[build.dist-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
-
-[build.branches-7-8]
-  GHC_VERSION = "7.8.4"
-  CABAL_VERSION = "1.22.4.0"
+#[build.dist-8-2]
+#  GHC_VERSION = "8.2.2"
+#  CABAL_VERSION = "2.0.0.1"
+#
+#[build.branches-8-2]
+#  GHC_VERSION = "8.2.2"
+#  CABAL_VERSION = "2.0.0.1"
 
 [build.dist-7-10]
-  HADDOCK = "true"
-  HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
   GHC_VERSION = "7.10.2"
-  CABAL_VERSION = "1.22.4.0"
+  CABAL_VERSION = "1.24.0.2"
 
 [build.branches-7-10]
-  HADDOCK = "true"
-  HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
   GHC_VERSION = "7.10.2"
-  CABAL_VERSION = "1.22.4.0"
+  CABAL_VERSION = "1.24.0.2"
 
 [build.dist-8-0]
-  GHC_VERSION = "8.0.1"
-  CABAL_VERSION = "1.24.0.0"
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
+  GHC_VERSION = "8.0.2"
+  CABAL_VERSION = "1.24.0.2"
 
 [build.branches-8-0]
-  GHC_VERSION = "8.0.1"
-  CABAL_VERSION = "1.24.0.0"
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
+  GHC_VERSION = "8.0.2"
+  CABAL_VERSION = "1.24.0.2"


### PR DESCRIPTION
Increasing Quickcheck support up to 2.11. Fixed change in monadicIO. Disorder version 0.0.2